### PR TITLE
Refactor as seeded content engine

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,3 +9,8 @@ repos:
     rev: v0.35.0
     hooks:
       - id: markdownlint
+  - repo: https://github.com/ansible-community/antsibull-changelog.git
+    rev: main # this will change when the next release of antsible includes the pre-commit hooks
+    hooks:
+      - id: antsibull-changelog-lint
+      - id: antsibull-changelog-lint-changelog-yaml

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -28,4 +28,4 @@ Minor Changes
 Breaking Changes / Porting Guide
 --------------------------------
 
-- All variable names have been edited and refactored. See `roles/controller/defaults/main.yml` for new variables and structure.
+- All variable names have been edited and refactored. See ``roles/controller/defaults/main.yml`` for new variables and structure.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,0 +1,31 @@
+========================================
+Aoc.Controller_Demo_Config Release Notes
+========================================
+
+.. contents:: Topics
+
+This changelog describes changes after version 3.0.0.
+
+v4.0.0
+======
+
+Release Summary
+---------------
+
+Refactored the collection with the intent of having a general use as a PoC for seeding content into automation controller.
+
+Major Changes
+-------------
+
+- Flags to deploy validated content, content lab content, or both.
+- Separated the ability to deploy validated content and content lab content.
+
+Minor Changes
+-------------
+
+- Introduced change log.
+
+Breaking Changes / Porting Guide
+--------------------------------
+
+- All variable names have been edited and refactored. See `roles/controller/defaults/main.yml` for new variables and structure.

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -1,0 +1,23 @@
+---
+ancestor: 3.0.0
+releases:
+  4.0.0:
+    release_date: "2023-07-19"
+    changes:
+      release_summary: Refactored the collection with the intent of having a general use as a PoC for seeding content into automation controller.
+      breaking_changes:
+        - All variable names have been edited and refactored. See `roles/controller/defaults/main.yml` for new variables and structure.
+      major_changes:
+        - Separated the ability to deploy validated content and content lab content.
+        - Flags to deploy validated content, content lab content, or both.
+      minor_changes:
+        - Introduced change log.
+    objects:
+      role:
+        - name: controller
+          description: Performs all of the operations to seed content in Ansible Automation Controller
+          namespace: null
+      playbook:
+        - name: playbook_configure_app
+          description: A playbook that can be used to initiate the operations.
+          namespace: null

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -1,23 +1,17 @@
----
 ancestor: 3.0.0
 releases:
   4.0.0:
-    release_date: "2023-07-19"
     changes:
-      release_summary: Refactored the collection with the intent of having a general use as a PoC for seeding content into automation controller.
       breaking_changes:
-        - All variable names have been edited and refactored. See `roles/controller/defaults/main.yml` for new variables and structure.
+      - All variable names have been edited and refactored. See ``roles/controller/defaults/main.yml``
+        for new variables and structure.
       major_changes:
-        - Separated the ability to deploy validated content and content lab content.
-        - Flags to deploy validated content, content lab content, or both.
+      - Flags to deploy validated content, content lab content, or both.
+      - Separated the ability to deploy validated content and content lab content.
       minor_changes:
-        - Introduced change log.
-    objects:
-      role:
-        - name: controller
-          description: Performs all of the operations to seed content in Ansible Automation Controller
-          namespace: null
-      playbook:
-        - name: playbook_configure_app
-          description: A playbook that can be used to initiate the operations.
-          namespace: null
+      - Introduced change log.
+      release_summary: Refactored the collection with the intent of having a general
+        use as a PoC for seeding content into automation controller.
+    fragments:
+    - 1-seeded-content-refactor.yml
+    release_date: '2023-07-19'

--- a/changelogs/config.yaml
+++ b/changelogs/config.yaml
@@ -1,0 +1,32 @@
+changelog_filename_template: ../CHANGELOG.rst
+changelog_filename_version_depth: 0
+changes_file: changelog.yaml
+changes_format: combined
+ignore_other_fragment_extensions: true
+keep_fragments: false
+mention_ancestor: true
+new_plugins_after_name: removed_features
+notesdir: fragments
+prelude_section_name: release_summary
+prelude_section_title: Release Summary
+sanitize_changelog: true
+sections:
+- - major_changes
+  - Major Changes
+- - minor_changes
+  - Minor Changes
+- - breaking_changes
+  - Breaking Changes / Porting Guide
+- - deprecated_features
+  - Deprecated Features
+- - removed_features
+  - Removed Features (previously deprecated)
+- - security_fixes
+  - Security Fixes
+- - bugfixes
+  - Bugfixes
+- - known_issues
+  - Known Issues
+title: Aoc.Controller_Demo_Config
+trivial_section_name: trivial
+use_fqcn: true

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,7 +1,7 @@
 ---
 namespace: aoc
 name: controller_demo_config
-version: 3.0.1
+version: 4.0.0
 authors:
   - Scott Harwell <sharwell@redhat.com>
 description: A collection of content for setting up Ansible on Cloud demos rapidly.

--- a/playbook_configure_aap.yml
+++ b/playbook_configure_aap.yml
@@ -1,7 +1,8 @@
 ---
-- name: Deploy Demo AoC Site
+- name: Deploy Ansible Automation Controller Seeded Content
   hosts: localhost
   connection: local
+  become: false
   gather_facts: false
   tasks:
     - name: Fail if variables not defined
@@ -18,6 +19,10 @@
           - "{{ lookup('env', 'RED_HAT_PASSWORD') | length > 0 }}"
         fail_msg: "Required variables not set"
 
-    - name: Configure Demo Site
+    - name: Start Notice
+      ansible.builtin.debug:
+        msg: This process will configure Ansible Automation Controller with seeded content.
+
+    - name: Run Controller Configuration Role
       ansible.builtin.import_role:
         name: controller

--- a/requirements.yml
+++ b/requirements.yml
@@ -12,3 +12,7 @@ collections:
     version: v2.0.0
     source: https://github.com/ansible-content-lab/aws.infrastructure_config_demos.git
     type: git
+  - name: cloud.azure_ops
+    source: https://github.com/redhat-cop/cloud.azure_ops.git
+    version: 2.0.0
+    type: git

--- a/requirements.yml
+++ b/requirements.yml
@@ -3,4 +3,4 @@ collections:
   - name: ansible.controller
     version: 4.4.0
   - name: awx.awx
-    version: 22.4.0
+    version: 22.5.0

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,18 +1,6 @@
 ---
 collections:
-  - name: awx.awx
-    version: 22.4.0
   - name: ansible.controller
     version: 4.4.0
-  - name: azure.infrastructure_config_demos
-    version: v1.6.0
-    source: https://github.com/ansible-content-lab/azure.infrastructure_config_demos.git
-    type: git
-  - name: aws.infrastructure_config_demos
-    version: v2.0.0
-    source: https://github.com/ansible-content-lab/aws.infrastructure_config_demos.git
-    type: git
-  - name: cloud.azure_ops
-    source: https://github.com/redhat-cop/cloud.azure_ops.git
-    version: 2.0.0
-    type: git
+  - name: awx.awx
+    version: 22.4.0

--- a/roles/controller/README.md
+++ b/roles/controller/README.md
@@ -25,7 +25,7 @@ This role configures the following components in Ansible Automation Controller t
 | Name                                   | Description                                                                                            |
 | -------------------------------------- | ------------------------------------------------------------------------------------------------------ |
 | `Cloud Services Execution Environment` | Latest version of the `ee-cloud-services-rhel8` execution environment published with Ansible on Azure. |
-| `Harwell - Cloud EE`                   | Custom EE with cloud content collections installed                                                     |
+| `Cloud EE`                   | Custom EE with cloud content collections installed                                                     |
 
 ### Inventories
 

--- a/roles/controller/defaults/main.yml
+++ b/roles/controller/defaults/main.yml
@@ -3,17 +3,28 @@ awx_organization: Default
 azure_region: eastus
 azure_resource_group: ansible_test
 credentials:
-  ssh_key_data: "{{ lookup('file', '/home/runner/.ssh/id_rsa_azure_demo') }}"
+  ssh:
+    user: vmuser
+    key_data: "{{ lookup('file', '/home/runner/.ssh/id_rsa_azure_demo') }}"
 job_templates:
-  admin_password: ansible12345!
-  ssh_public_key: "{% raw %}{{ lookup('file', '/home/runner/.ssh/id_rsa_azure_demo.pub') }}{% endraw %}"
-  log_ws_name: log-ws
-  vnet_route_table_name: vnet-rt
-  vnet_name: vnet-test
-  vnet_cidr: 10.0.200.0/23
-  subnet_name: subnet-test
-  subnet_cidr: 10.0.200.0/24
+  demo:
+    delete_demo_template: true
+  log_analytics:
+    ws_name: log-ws
+  vnet:
+    route_table_name: vnet-rt
+    vnet_name: vnet-test
+    vnet_cidr: 10.0.200.0/23
+    subnet_name: subnet-test
+    subnet_cidr: 10.0.200.0/24
 projects:
-  azure_demo_project_url: https://github.com/ansible-cloud/azure.git
-  azure_lab_roles_url: https://github.com/ansible-content-lab/azure.infrastructure_config_demos.git
-  aws_lab_roles_url: https://github.com/ansible-content-lab/aws.infrastructure_config_demos.git
+  azure_demo_project:
+    url: https://github.com/ansible-cloud/azure.git
+  azure_lab_roles:
+    url: https://github.com/ansible-content-lab/azure.infrastructure_config_demos.git
+  aws_lab_roles:
+    url: https://github.com/ansible-content-lab/aws.infrastructure_config_demos.git
+  azure_seeded_content:
+    url: https://github.com/redhat-cop/cloud.azure_ops.git
+seed_lab_content: false
+seed_validated_content: true

--- a/roles/controller/defaults/main.yml
+++ b/roles/controller/defaults/main.yml
@@ -26,11 +26,27 @@ inventories:
   localhost:
     name: localhost
 job_templates:
+  create_rhel_vm:
+    name: Content Lab - Azure - Create RHEL VM
+  delete_rhel_vm:
+    name: Content Lab - Azure - Create RHEL VM
   demo:
     delete_demo_template: true
-  log_analytics:
+  dnf_update:
+    name: Content Lab - Azure - Run DNF Update
+  create_log_analytics_ws:
+    name: Content Lab - Azure - Create Log Analytics Workspace
     ws_name: log-ws
+  install_arc_agent:
+    name: Content Lab - Azure - Install Arc Agent
+  install_log_analytics:
+    name: Content Lab - Azure - Install Log Analytics Agent
+  replace_log_analytics_with_azure_monitor:
+    name: Content Lab - Azure - Replace Log Analytics with Azure Monitor
+  uninstall_log_analytics:
+    name: Content Lab - Azure - Uninstall Log Analytics Agent
   vnet:
+    name: Content Lab - Azure - Create VNET
     route_table_name: vnet-rt
     vnet_name: vnet-test
     vnet_cidr: 10.0.200.0/23

--- a/roles/controller/defaults/main.yml
+++ b/roles/controller/defaults/main.yml
@@ -3,10 +3,19 @@ awx_organization: Default
 azure_region: eastus
 azure_resource_group: ansible_test
 credentials:
+  azure_service_principal:
+    name: Azure Service Principal
+  controller:
+    name: Ansible Automation Controller
+  red_hat_registry:
+    name: Red Hat Registry
   ssh:
+    name: VM SSH Credential
     user: vmuser
     key_data: "{{ lookup('file', '/home/runner/.ssh/id_ed25519') }}"
 execution_environments:
+  cloud_services_ee_name: Cloud Services Execution Environment
+  cloud_ee_name: Cloud EE
   set_cloud_services_ee_default: false
   set_cloud_ee_default: false
 job_templates:

--- a/roles/controller/defaults/main.yml
+++ b/roles/controller/defaults/main.yml
@@ -14,10 +14,17 @@ credentials:
     user: vmuser
     key_data: "{{ lookup('file', '/home/runner/.ssh/id_ed25519') }}"
 execution_environments:
-  cloud_services_ee_name: Cloud Services Execution Environment
-  cloud_ee_name: Cloud EE
-  set_cloud_services_ee_default: false
-  set_cloud_ee_default: false
+  cloud_services:
+    name: Cloud Services Execution Environment
+    set_default: false
+  cloud_ee:
+    name: Cloud EE
+    set_default: false
+inventories:
+  azure:
+    name: Azure
+  localhost:
+    name: localhost
 job_templates:
   demo:
     delete_demo_template: true

--- a/roles/controller/defaults/main.yml
+++ b/roles/controller/defaults/main.yml
@@ -5,7 +5,10 @@ azure_resource_group: ansible_test
 credentials:
   ssh:
     user: vmuser
-    key_data: "{{ lookup('file', '/home/runner/.ssh/id_rsa_azure_demo') }}"
+    key_data: "{{ lookup('file', '/home/runner/.ssh/id_ed25519') }}"
+execution_environments:
+  set_cloud_services_ee_default: false
+  set_cloud_ee_default: false
 job_templates:
   demo:
     delete_demo_template: true

--- a/roles/controller/defaults/main.yml
+++ b/roles/controller/defaults/main.yml
@@ -31,12 +31,16 @@ job_templates:
     subnet_cidr: 10.0.200.0/24
 projects:
   azure_demo_project:
+    name: Ansible Cloud Content Lab - Azure Demo
     url: https://github.com/ansible-cloud/azure.git
   azure_lab_roles:
+    name: Ansible Cloud Content Lab - Azure Roles
     url: https://github.com/ansible-content-lab/azure.infrastructure_config_demos.git
   aws_lab_roles:
+    name: Ansible Cloud Content Lab - AWS Roles
     url: https://github.com/ansible-content-lab/aws.infrastructure_config_demos.git
   azure_seeded_content:
+    name: Ansible Validated Content - Azure Demos
     url: https://github.com/redhat-cop/cloud.azure_ops.git
 seed_lab_content: false
 seed_validated_content: true

--- a/roles/controller/defaults/main.yml
+++ b/roles/controller/defaults/main.yml
@@ -65,5 +65,15 @@ projects:
   azure_seeded_content:
     name: Ansible Validated Content - Azure Demos
     url: https://github.com/redhat-cop/cloud.azure_ops.git
+schedules:
+  ephemeral_workload:
+    name: Content Lab - RHEL Ephemeral VM Workflow
+workflows:
+  arc_log_migration:
+    name: Content Lab - Azure - Arc Log Migration
+  ephemeral_workload:
+    name: Content Lab - Linux - Ephemeral VM Workflow
+  install_log_analytics:
+    name: Content Lab - Azure - Install Log Analytics Workflow
 seed_lab_content: false
 seed_validated_content: true

--- a/roles/controller/tasks/credentials.yml
+++ b/roles/controller/tasks/credentials.yml
@@ -1,7 +1,7 @@
 ---
 - name: Add Red Hat Registry Credential
   ansible.controller.credential:
-    name: Red Hat Registry
+    name: "{{ credentials.red_hat_registry.name }}"
     description: Red Hat Registry
     organization: "{{ awx_organization }}"
     state: present
@@ -20,7 +20,7 @@
 
 - name: Add Azure Credential
   ansible.controller.credential:
-    name: Azure Service Principal
+    name: "{{ credentials.azure_service_principal.name }}"
     description: Azure Service Principal
     organization: "{{ awx_organization }}"
     state: present
@@ -36,13 +36,14 @@
     - lookup('env', 'AZURE_SUBSCRIPTION_ID') is defined
     - lookup('env', 'AZURE_CLIENT_ID') is defined
     - lookup('env', 'AZURE_SECRET') is defined
+    - credentials.azure_service_principal.name is defined
   register: azure_credential
   tags:
     - credentials
 
-- name: Add Azure VM SSH Credential
+- name: Add VM SSH Credential
   ansible.controller.credential:
-    name: Azure VM SSH Credential
+    name: "{{ credentials.ssh.name }}"
     description: SSH key for Azure linux hosts
     organization: "{{ awx_organization }}"
     state: present
@@ -53,15 +54,16 @@
   no_log: false
   ignore_errors: true
   when:
+    - credentials.ssh.name is defined
     - credentials.ssh.user is defined
     - credentials.ssh.key_data is defined
-  register: azure_vm_credential
+  register: vm_credential
   tags:
     - credentials
 
 - name: Add Ansible Automation Controller Credential
   ansible.controller.credential:
-    name: Ansible Automation Controller
+    name: "{{ credentials.controller.name }}"
     description: Credential for API calls to Ansible Controller
     organization: Default
     state: present

--- a/roles/controller/tasks/credentials.yml
+++ b/roles/controller/tasks/credentials.yml
@@ -12,6 +12,7 @@
       password: "{{ lookup('env', 'RED_HAT_PASSWORD') }}"
   no_log: true
   when:
+    - (seed_lab_content | bool)
     - lookup('env', 'RED_HAT_ACCOUNT') is defined
     - lookup('env', 'RED_HAT_PASSWORD') is defined
   register: rh_credential
@@ -32,6 +33,7 @@
       secret: "{{ lookup('env', 'AZURE_SECRET') }}"
   no_log: true
   when:
+    - (seed_lab_content | bool)
     - lookup('env', 'AZURE_TENANT') is defined
     - lookup('env', 'AZURE_SUBSCRIPTION_ID') is defined
     - lookup('env', 'AZURE_CLIENT_ID') is defined
@@ -54,6 +56,7 @@
   no_log: false
   ignore_errors: true
   when:
+    - (seed_lab_content | bool)
     - credentials.ssh.name is defined
     - credentials.ssh.user is defined
     - credentials.ssh.key_data is defined
@@ -74,6 +77,7 @@
       password: "{{ lookup('env', 'CONTROLLER_PASSWORD') }}"
   no_log: true
   when:
+    - (seed_lab_content | bool)
     - lookup('env', 'CONTROLLER_HOST') is defined
     - lookup('env', 'CONTROLLER_USERNAME') is defined
     - lookup('env', 'CONTROLLER_PASSWORD') is defined

--- a/roles/controller/tasks/credentials.yml
+++ b/roles/controller/tasks/credentials.yml
@@ -11,6 +11,10 @@
       username: "{{ lookup('env', 'RED_HAT_ACCOUNT') }}"
       password: "{{ lookup('env', 'RED_HAT_PASSWORD') }}"
   no_log: true
+  when:
+    - lookup('env', 'RED_HAT_ACCOUNT') is defined
+    - lookup('env', 'RED_HAT_PASSWORD') is defined
+  register: rh_credential
   tags:
     - credentials
 
@@ -27,6 +31,12 @@
       client: "{{ lookup('env', 'AZURE_CLIENT_ID') }}"
       secret: "{{ lookup('env', 'AZURE_SECRET') }}"
   no_log: true
+  when:
+    - lookup('env', 'AZURE_TENANT') is defined
+    - lookup('env', 'AZURE_SUBSCRIPTION_ID') is defined
+    - lookup('env', 'AZURE_CLIENT_ID') is defined
+    - lookup('env', 'AZURE_SECRET') is defined
+  register: azure_credential
   tags:
     - credentials
 
@@ -38,10 +48,14 @@
     state: present
     credential_type: Machine
     inputs:
-      username: azureuser
-      ssh_key_data: "{{ credentials.ssh_key_data }}"
+      username: "{{ credentials.ssh.user }}"
+      ssh_key_data: "{{ credentials.ssh.key_data }}"
   no_log: false
   ignore_errors: true
+  when:
+    - credentials.ssh.user is defined
+    - credentials.ssh.key_data is defined
+  register: azure_vm_credential
   tags:
     - credentials
 
@@ -57,5 +71,10 @@
       username: "{{ lookup('env', 'CONTROLLER_USERNAME') }}"
       password: "{{ lookup('env', 'CONTROLLER_PASSWORD') }}"
   no_log: true
+  when:
+    - lookup('env', 'CONTROLLER_HOST') is defined
+    - lookup('env', 'CONTROLLER_USERNAME') is defined
+    - lookup('env', 'CONTROLLER_PASSWORD') is defined
+  register: controller_credential
   tags:
     - credentials

--- a/roles/controller/tasks/execution_environments.yml
+++ b/roles/controller/tasks/execution_environments.yml
@@ -22,6 +22,8 @@
     - cloud_services_ee.id is defined
     - execution_environments.set_cloud_services_ee_default is defined
     - execution_environments.set_cloud_services_ee_default
+  tags:
+    - ees
 
 - name: Add Test Cloud Execution Environment
   ansible.controller.execution_environment:
@@ -44,3 +46,5 @@
     - cloud_ee.id is defined
     - execution_environments.set_cloud_ee_default is defined
     - execution_environments.set_cloud_ee_default
+  tags:
+    - ees

--- a/roles/controller/tasks/execution_environments.yml
+++ b/roles/controller/tasks/execution_environments.yml
@@ -8,19 +8,25 @@
     credential: Red Hat Registry
     pull: always
     state: present
+  register: cloud_services_ee
+  when:
+    - seed_validated_content
   tags:
     - ees
 
 - name: Add Test Cloud Execution Environment
   ansible.controller.execution_environment:
-    name: Harwell - Cloud EE
+    name: Cloud EE
     image: quay.io/scottharwell/cloud-ee:latest
     state: present
     pull: always
-  register: harwell_ee
+  register: cloud_ee
+  when:
+    - seed_content_lab
   tags:
     - ees
 
 - name: Set EE as global default
   ansible.builtin.set_fact:
-    default_execution_environment: "{{ harwell_ee.id | int }}"
+    default_execution_environment: "{{ cloud_ee.id | int }}"
+  when: cloud_ee is defined

--- a/roles/controller/tasks/execution_environments.yml
+++ b/roles/controller/tasks/execution_environments.yml
@@ -1,7 +1,7 @@
 ---
 - name: Add EE Cloud Services Execution Environment
   ansible.controller.execution_environment:
-    name: "{{ execution_environments.cloud_services_ee_name }}"
+    name: "{{ execution_environments.cloud_services.name }}"
     description: Red Hat Cloud Services EE
     organization: "{{ awx_organization | default('') }}"
     image: registry.redhat.io/ansible-automation-platform-24/ee-cloud-services-rhel8:latest
@@ -20,14 +20,14 @@
   when: 
     - seed_validated_content
     - cloud_services_ee.id is defined
-    - execution_environments.set_cloud_services_ee_default is defined
-    - execution_environments.set_cloud_services_ee_default
+    - execution_environments.cloud_services.set_default is defined
+    - execution_environments.cloud_services.set_default
   tags:
     - ees
 
 - name: Add Test Cloud Execution Environment
   ansible.controller.execution_environment:
-    name: "{{ execution_environments.cloud_ee_name }}"
+    name: "{{ execution_environments.cloud_ee.name }}"
     description: Cloud Content Lab EE that contains dependencies for major hyperscaler collections.
     image: quay.io/scottharwell/cloud-ee:latest
     state: present
@@ -44,7 +44,7 @@
   when: 
     - seed_lab_content
     - cloud_ee.id is defined
-    - execution_environments.set_cloud_ee_default is defined
-    - execution_environments.set_cloud_ee_default
+    - execution_environments.cloud_ee.default is defined
+    - execution_environments.cloud_ee.default
   tags:
     - ees

--- a/roles/controller/tasks/execution_environments.yml
+++ b/roles/controller/tasks/execution_environments.yml
@@ -14,6 +14,14 @@
   tags:
     - ees
 
+- name: Set Cloud Services EE as global default
+  ansible.builtin.set_fact:
+    default_execution_environment: "{{ cloud_services_ee.id | int }}"
+  when: 
+    - cloud_services_ee is defined
+    - execution_environments.set_cloud_services_ee_default is defined
+    - execution_environments.set_cloud_services_ee_default
+
 - name: Add Test Cloud Execution Environment
   ansible.controller.execution_environment:
     name: Cloud EE
@@ -26,7 +34,10 @@
   tags:
     - ees
 
-- name: Set EE as global default
+- name: Set Cloud EE as global default
   ansible.builtin.set_fact:
     default_execution_environment: "{{ cloud_ee.id | int }}"
-  when: cloud_ee is defined
+  when: 
+    - cloud_ee is defined
+    - execution_environments.set_cloud_ee_default is defined
+    - execution_environments.set_cloud_ee_default

--- a/roles/controller/tasks/execution_environments.yml
+++ b/roles/controller/tasks/execution_environments.yml
@@ -1,7 +1,7 @@
 ---
 - name: Add EE Cloud Services Execution Environment
   ansible.controller.execution_environment:
-    name: Cloud Services Execution Environment
+    name: "{{ execution_environments.cloud_services_ee_name }}"
     description: Red Hat Cloud Services EE
     organization: "{{ awx_organization | default('') }}"
     image: registry.redhat.io/ansible-automation-platform-24/ee-cloud-services-rhel8:latest
@@ -18,19 +18,21 @@
   ansible.builtin.set_fact:
     default_execution_environment: "{{ cloud_services_ee.id | int }}"
   when: 
-    - cloud_services_ee is defined
+    - seed_validated_content
+    - cloud_services_ee.id is defined
     - execution_environments.set_cloud_services_ee_default is defined
     - execution_environments.set_cloud_services_ee_default
 
 - name: Add Test Cloud Execution Environment
   ansible.controller.execution_environment:
-    name: Cloud EE
+    name: "{{ execution_environments.cloud_ee_name }}"
+    description: Cloud Content Lab EE that contains dependencies for major hyperscaler collections.
     image: quay.io/scottharwell/cloud-ee:latest
     state: present
     pull: always
   register: cloud_ee
   when:
-    - seed_content_lab
+    - seed_lab_content
   tags:
     - ees
 
@@ -38,6 +40,7 @@
   ansible.builtin.set_fact:
     default_execution_environment: "{{ cloud_ee.id | int }}"
   when: 
-    - cloud_ee is defined
+    - seed_lab_content
+    - cloud_ee.id is defined
     - execution_environments.set_cloud_ee_default is defined
     - execution_environments.set_cloud_ee_default

--- a/roles/controller/tasks/execution_environments.yml
+++ b/roles/controller/tasks/execution_environments.yml
@@ -10,18 +10,19 @@
     state: present
   register: cloud_services_ee
   when:
-    - seed_validated_content
+    - (seed_validated_content | bool)
   tags:
     - ees
 
 - name: Set Cloud Services EE as global default
   ansible.builtin.set_fact:
     default_execution_environment: "{{ cloud_services_ee.id | int }}"
-  when: 
-    - seed_validated_content
+  when:
+    - (seed_validated_content | bool)
     - cloud_services_ee.id is defined
     - execution_environments.cloud_services.set_default is defined
     - execution_environments.cloud_services.set_default
+    - (execution_environments.cloud_services.set_default | bool)
   tags:
     - ees
 
@@ -34,7 +35,7 @@
     pull: always
   register: cloud_ee
   when:
-    - seed_lab_content
+    - (seed_lab_content | bool)
   tags:
     - ees
 
@@ -42,9 +43,9 @@
   ansible.builtin.set_fact:
     default_execution_environment: "{{ cloud_ee.id | int }}"
   when: 
-    - seed_lab_content
+    - (seed_lab_content | bool)
     - cloud_ee.id is defined
-    - execution_environments.cloud_ee.default is defined
-    - execution_environments.cloud_ee.default
+    - execution_environments.cloud_ee.set_default is defined
+    - (execution_environments.cloud_ee.set_default | bool)
   tags:
     - ees

--- a/roles/controller/tasks/inventories.yml
+++ b/roles/controller/tasks/inventories.yml
@@ -5,6 +5,7 @@
     description: localhost
     organization: "{{ awx_organization }}"
     state: present
+  register: localhost_inventory
   tags:
     - inventories
 
@@ -13,6 +14,8 @@
     name: localhost
     inventory: localhost
     state: present
+  when:
+    - localhost_inventory is defined
   tags:
     - inventories
 
@@ -24,7 +27,7 @@
     state: present
   register: azure_inventory
   when:
-    - seed_content_lab
+    - seed_lab_content
   tags:
     - inventories
 
@@ -43,7 +46,7 @@
     source_path: inventory/inventory.azure_rm.yml
     verbosity: 0
   when:
-    - seed_content_lab
+    - seed_lab_content
     - azure_inventory is defined
   tags:
     - inventories

--- a/roles/controller/tasks/inventories.yml
+++ b/roles/controller/tasks/inventories.yml
@@ -29,7 +29,7 @@
     state: present
   register: azure_inventory
   when:
-    - seed_lab_content
+    - (seed_lab_content | bool)
     - inventories.azure.name is defined
   tags:
     - inventories
@@ -49,7 +49,7 @@
     source_path: inventory/inventory.azure_rm.yml
     verbosity: 0
   when:
-    - seed_lab_content
+    - (seed_lab_content | bool)
     - azure_inventory is defined
     - inventories.azure.name is defined
     - azure_credential is defined

--- a/roles/controller/tasks/inventories.yml
+++ b/roles/controller/tasks/inventories.yml
@@ -5,8 +5,6 @@
     description: localhost
     organization: "{{ awx_organization }}"
     state: present
-    variables:
-      ansible_python_interpreter: /usr/bin/python3
   tags:
     - inventories
 
@@ -24,6 +22,9 @@
     description: Azure Inventory
     organization: "{{ awx_organization }}"
     state: present
+  register: azure_inventory
+  when:
+    - seed_content_lab
   tags:
     - inventories
 
@@ -33,7 +34,7 @@
     description: Creates inventory from Azure sources
     inventory: Azure
     credential: Azure Service Principal
-    execution_environment: Harwell - Cloud EE
+    execution_environment: Cloud EE
     overwrite: true
     update_on_launch: true
     organization: "{{ awx_organization }}"
@@ -41,5 +42,8 @@
     source_project: Ansible Cloud Content Lab - Azure Roles
     source_path: inventory/inventory.azure_rm.yml
     verbosity: 0
+  when:
+    - seed_content_lab
+    - azure_inventory is defined
   tags:
     - inventories

--- a/roles/controller/tasks/inventories.yml
+++ b/roles/controller/tasks/inventories.yml
@@ -1,18 +1,20 @@
 ---
 - name: Create localhost inventory
   ansible.controller.inventory:
-    name: localhost
+    name: "{{ inventories.localhost.name }}"
     description: localhost
     organization: "{{ awx_organization }}"
     state: present
   register: localhost_inventory
+  when:
+    - inventories.localhost.name is defined
   tags:
     - inventories
 
 - name: Add localhost host to inventory
   ansible.controller.host:
     name: localhost
-    inventory: localhost
+    inventory: "{{ inventories.localhost.name }}"
     state: present
   when:
     - localhost_inventory is defined
@@ -21,13 +23,14 @@
 
 - name: Create Azure Inventory
   ansible.controller.inventory:
-    name: Azure
+    name: "{{ inventories.azure.name }}"
     description: Azure Inventory
     organization: "{{ awx_organization }}"
     state: present
   register: azure_inventory
   when:
     - seed_lab_content
+    - inventories.azure.name is defined
   tags:
     - inventories
 
@@ -35,8 +38,8 @@
   ansible.controller.inventory_source:
     name: Azure Dynamic Inventory
     description: Creates inventory from Azure sources
-    inventory: Azure
-    credential: Azure Service Principal
+    inventory: "{{ inventories.azure.name }}"
+    credential: "{{ credentials.azure_service_principal.name }}"
     execution_environment: Cloud EE
     overwrite: true
     update_on_launch: true
@@ -48,5 +51,10 @@
   when:
     - seed_lab_content
     - azure_inventory is defined
+    - inventories.azure.name is defined
+    - azure_credential is defined
+    - credentials.azure_service_principal.name is defined
+    - cloud_ee is defined
+    - execution_environments.cloud_services.name is defined
   tags:
     - inventories

--- a/roles/controller/tasks/job_templates.yml
+++ b/roles/controller/tasks/job_templates.yml
@@ -15,7 +15,7 @@
     name: Content Lab - Azure - Create Resource Group
     inventory: localhost
     playbook: playbook_create_resource_group.yml
-    project: "{{ content_lab_project_azure }}"
+    project: "{{ projects.azure_lab_roles.name }}"
     extra_vars:
       resource_group: "{{ azure_resource_group }}"
       region: "{{ azure_region }}"
@@ -26,6 +26,7 @@
     - azure_credential is defined
     - credentials.azure_service_principal.name is defined
     - content_lab_project_azure is defined
+    - projects.azure_lab_roles.name is defined
   tags:
     - templates
 
@@ -34,11 +35,11 @@
     name: Content Lab - Azure - Create VNET
     inventory: localhost
     playbook: playbook_create_vnet.yml
-    project: "{{ content_lab_project_azure }}"
+    project: "{{ projects.azure_lab_roles.name }}"
     extra_vars:
       resource_group: "{{ azure_resource_group }}"
       region: "{{ azure_region }}"
-      route_table_name: "{{ job_templates.vnet.vnet_route_table_name }}"
+      route_table_name: "{{ job_templates.vnet.route_table_name }}"
       vnet_name: "{{ job_templates.vnet.vnet_name }}"
       vnet_cidr: "{{ job_templates.vnet.vnet_cidr }}"
       subnet_name: "{{ job_templates.vnet.subnet_name }}"
@@ -50,6 +51,7 @@
     - azure_credential is defined
     - credentials.azure_service_principal.name is defined
     - content_lab_project_azure is defined
+    - projects.azure_lab_roles.name is defined
   tags:
     - templates
 
@@ -58,7 +60,7 @@
     name: Content Lab - Azure - Create RHEL VM
     inventory: localhost
     playbook: playbook_create_vm.yml
-    project: "{{ content_lab_project_azure.name }}"
+    project: "{{ projects.azure_lab_roles.name }}"
     extra_vars:
       resource_group: "{{ azure_resource_group }}"
       region: "{{ azure_region }}"
@@ -84,6 +86,7 @@
     - azure_credential is defined
     - credentials.azure_service_principal.name is defined
     - content_lab_project_azure is defined
+    - projects.azure_lab_roles.name is defined
   register: create_rhel_vm_template
   tags:
     - templates
@@ -93,7 +96,7 @@
     name: Content Lab - Azure - Delete RHEL VM
     inventory: localhost
     playbook: playbook_delete_vm.yml
-    project: "{{ content_lab_project_azure.name }}"
+    project: "{{ projects.azure_lab_roles.name }}"
     extra_vars:
       resource_group: "{{ azure_resource_group }}"
       vm_name: rhel9-test
@@ -107,6 +110,7 @@
     - azure_credential is defined
     - credentials.azure_service_principal.name is defined
     - content_lab_project_azure is defined
+    - projects.azure_lab_roles.name is defined
   register: delete_rhel_vm_template
   tags:
     - templates
@@ -116,7 +120,7 @@
     name: Content Lab - Azure - Create Windows Server VM
     inventory: localhost
     playbook: playbook_create_vm.yml
-    project: "{{ content_lab_project_azure }}"
+    project: "{{ projects.azure_lab_roles.name }}"
     extra_vars:
       resource_group: "{{ azure_resource_group }}"
       region: "{{ azure_region }}"
@@ -138,6 +142,7 @@
     - azure_credential is defined
     - credentials.azure_service_principal.name is defined
     - content_lab_project_azure is defined
+    - projects.azure_lab_roles.name is defined
   register: create_windows_vm_template
   tags:
     - templates
@@ -147,7 +152,7 @@
     name: Content Lab - Azure - Delete Windows VM
     inventory: localhost
     playbook: playbook_delete_vm.yml
-    project: "{{ content_lab_project_azure }}"
+    project: "{{ projects.azure_lab_roles.name }}"
     extra_vars:
       resource_group: "{{ azure_resource_group }}"
       vm_name:  win2022-test
@@ -161,6 +166,7 @@
     - azure_credential is defined
     - credentials.azure_service_principal.name is defined
     - content_lab_project_azure is defined
+    - projects.azure_lab_roles.name is defined
   register: delete_windows_vm_template
   tags:
     - templates
@@ -170,7 +176,7 @@
     name: Content Lab - Azure - Delete Resource Group
     inventory: localhost
     playbook: playbook_delete_resource_group.yml
-    project: "{{ content_lab_project_azure.name }}"
+    project: "{{ projects.azure_lab_roles.name }}"
     extra_vars:
       resource_group: "{{ azure_resource_group }}"
       region: "{{ azure_region }}"
@@ -181,6 +187,7 @@
     - azure_credential is defined
     - credentials.azure_service_principal.name is defined
     - content_lab_project_azure is defined
+    - projects.azure_lab_roles.name is defined
   register: delete_resource_group_template
   tags:
     - templates
@@ -190,7 +197,7 @@
     name: Content Lab - Azure - Create Network Peering Demo
     inventory: localhost
     playbook: playbook_create_transit_network.yml
-    project: "{{ content_lab_project_azure.name }}"
+    project: "{{ projects.azure_lab_roles.name }}"
     extra_vars:
       resource_group: "{{ azure_resource_group }}"
       region: "{{ azure_region }}"
@@ -206,6 +213,7 @@
     - azure_credential is defined
     - credentials.azure_service_principal.name is defined
     - content_lab_project_azure is defined
+    - projects.azure_lab_roles.name is defined
   register: create_network_peering_demo_template
   tags:
     - templates
@@ -213,7 +221,7 @@
 - name: Content Lab - Azure - Delete Network Peering Demo
   ansible.controller.job_template:
     name: Content Lab - Azure - Delete Network Peering Demo
-    project: "{{ content_lab_project_azure.name }}"
+    project: "{{ projects.azure_lab_roles.name }}"
     playbook: playbook_delete_transit_network.yml
     inventory: localhost
     extra_vars:
@@ -227,6 +235,7 @@
     - azure_credential is defined
     - credentials.azure_service_principal.name is defined
     - content_lab_project_azure is defined
+    - projects.azure_lab_roles.name is defined
   register: delete_network_peering_demo_template
   tags:
     - templates
@@ -235,7 +244,7 @@
   ansible.controller.job_template:
     name: Content Lab - Azure - Run DNF Update
     job_type: run
-    project: "{{ content_lab_project_azure.name }}"
+    project: "{{ projects.azure_lab_roles.name }}"
     playbook: playbook_update_rhel_vms.yml
     inventory: "{{ azure_inventory.name }}"
     limit: rhel
@@ -249,6 +258,7 @@
     - vm_credential is defined
     - credentials.ssh.name is defined
     - content_lab_project_azure is defined
+    - projects.azure_lab_roles.name is defined
   register: rhel_vm_update_template
   tags:
     - templates
@@ -258,7 +268,7 @@
     name: Content Lab - Azure - Install Arc Agent
     inventory: "{{ azure_inventory.name }}"
     playbook: playbook_install_arc_agent.yml
-    project: "{{ content_lab_project_azure.name }}"
+    project: "{{ projects.azure_lab_roles.name }}"
     extra_vars: 
       resource_group: "{{ azure_resource_group }}"
       region: "{{ azure_region }}"
@@ -280,6 +290,7 @@
     - vm_credential is defined
     - credentials.ssh.name is defined
     - content_lab_project_azure is defined
+    - projects.azure_lab_roles.name is defined
   register: install_arc_agent_template
   tags:
     - templates
@@ -289,7 +300,7 @@
     name: Content Lab - Azure - Enable Arc Extensions
     inventory: "{{ azure_inventory.name }}"
     playbook: playbook_enable_arc_extension.yml
-    project: "{{ content_lab_project_azure.name }}"
+    project: "{{ projects.azure_lab_roles.name }}"
     extra_vars: 
       resource_group: "{{ azure_resource_group }}"
       region: "{{ azure_region }}"
@@ -303,6 +314,7 @@
     - azure_credential is defined
     - credentials.azure_service_principal.name is defined
     - content_lab_project_azure is defined
+    - projects.azure_lab_roles.name is defined
   register: enable_arc_extensions_template
   tags:
     - templates
@@ -312,7 +324,7 @@
     name: Content Lab - Azure - Disable Arc Extensions
     inventory: "{{ azure_inventory.name }}"
     playbook: playbook_disable_arc_extension.yml
-    project: "{{ content_lab_project_azure.name }}"
+    project: "{{ projects.azure_lab_roles.name }}"
     extra_vars: 
       resource_group_name: "{{ azure_resource_group }}"
       region: "{{ azure_region }}"
@@ -326,6 +338,7 @@
     - azure_credential is defined
     - credentials.azure_service_principal.name is defined
     - content_lab_project_azure is defined
+    - projects.azure_lab_roles.name is defined
   register: disable_arc_extensions_template
   tags:
     - templates
@@ -335,7 +348,7 @@
     name: Content Lab - Azure - Replace Log Analytics with Azure Monitor
     inventory: "{{ azure_inventory.name }}"
     playbook: playbook_replace_log_analytics_with_arc_linux.yml
-    project: "{{ content_lab_project_azure.name }}"
+    project: "{{ projects.azure_lab_roles.name }}"
     extra_vars:
       region: "{{ azure_region }}"
       resource_group: "{{ azure_resource_group }}"
@@ -347,6 +360,7 @@
     - azure_credential is defined
     - credentials.azure_service_principal.name is defined
     - content_lab_project_azure is defined
+    - projects.azure_lab_roles.name is defined
   register: replace_log_analytics_with_azure_monitor_template
   tags:
     - templates
@@ -356,7 +370,7 @@
     name: Azure - Create Log Analytics Workspace
     inventory: localhost
     playbook: playbook_create_log_analytics_workspace.yml
-    project: "{{ content_lab_project_azure.name }}"
+    project: "{{ projects.azure_lab_roles.name }}"
     credentials:
       - "{{ credentials.ssh.name }}"
     extra_vars:
@@ -368,6 +382,7 @@
     - vm_credential is defined
     - credentials.ssh.name is defined
     - content_lab_project_azure is defined
+    - projects.azure_lab_roles.name is defined
   register: create_log_analytics_workspace_template
   tags:
     - templates
@@ -377,7 +392,7 @@
     name: Azure - Install Log Analytics Agent
     inventory: "{{ azure_inventory.name }}"
     playbook: playbook_install_log_analytics_agent.yml
-    project: "{{ content_lab_project_azure.name }}"
+    project: "{{ projects.azure_lab_roles.name }}"
     credentials:
       - "{{ credentials.ssh.name }}"
     extra_vars:
@@ -392,6 +407,7 @@
     - vm_credential is defined
     - credentials.ssh.name is defined
     - content_lab_project_azure is defined
+    - projects.azure_lab_roles.name is defined
   register: install_log_analytics_agent_template
   tags:
     - templates
@@ -401,7 +417,7 @@
     name: Content Lab - Azure - Uninstall Log Analytics Agent
     inventory: "{{ azure_inventory.name }}"
     playbook: playbook_uninstall_log_analytics_agent.yml
-    project: "{{ content_lab_project_azure.name }}"
+    project: "{{ projects.azure_lab_roles.name }}"
     credentials:
       - "{{ credentials.ssh.name }}"
     become_enabled: true
@@ -412,6 +428,7 @@
     - vm_credential is defined
     - credentials.ssh.name is defined
     - content_lab_project_azure is defined
+    - projects.azure_lab_roles.name is defined
   register: uninstall_log_analytics_agent_template
   tags:
     - templates
@@ -420,7 +437,7 @@
   ansible.controller.job_template:
     name: Content Lab - Azure Demos - Ephemeral Workload Test
     job_type: run
-    project: "{{ content_lab_project_demo.name }}"
+    project: "{{ projects.azure_demo_project.name }}"
     playbook: project/emphemeral_workload_test.yml
     inventory: localhost
     credentials:
@@ -439,6 +456,7 @@
     - controller_credential is defined
     - credentials.controller.name is defined
     - content_lab_project_demo is defined
+    - projects.azure_demo_project.name is defined
   register: ephemeral_workload_template
   tags:
     - templates
@@ -448,7 +466,7 @@
     name: Validated Content - Azure web application deployment demo
     job_type: run
     execution_environment: "{{ execution_environments.cloud_services_ee_name }}"
-    project: "{{ seeded_content_project_azure.name }}"
+    project: "{{ projects.azure_seeded_content.name }}"
     playbook: playbooks/webapp.yml
     ask_credential_on_launch: true
     ask_inventory_on_launch: true
@@ -463,6 +481,7 @@
     - cloud_services_ee is defined
     - execution_environments.cloud_services_ee_name is defined
     - seeded_content_project_azure is defined
+    - projects.azure_seeded_content.name is defined
   register: ephemeral_workload_template
   tags:
     - templates
@@ -472,7 +491,7 @@
     name: Validated Content - Azure web application migration demo
     job_type: run
     execution_environment: "{{ execution_environments.cloud_services_ee_name }}"
-    project: "{{ seeded_content_project_azure.name }}"
+    project: "{{ projects.azure_seeded_content.name }}"
     playbook: playbooks/vmss_migrate.yml
     ask_credential_on_launch: true
     ask_inventory_on_launch: true
@@ -488,6 +507,7 @@
     - cloud_services_ee is defined
     - execution_environments.cloud_services_ee_name is defined
     - seeded_content_project_azure is defined
+    - projects.azure_seeded_content.name is defined
   register: ephemeral_workload_template
   tags:
     - templates

--- a/roles/controller/tasks/job_templates.yml
+++ b/roles/controller/tasks/job_templates.yml
@@ -421,3 +421,50 @@
   register: ephemeral_workload_template
   tags:
     - templates
+
+- name: Azure web application deployment demo
+  ansible.controller.job_template:
+    name: Azure web application deployment demo
+    job_type: run
+    execution_environment: "{{ cloud_services_ee.name }}"
+    project: "{{ seeded_content_project_azure.name }}"
+    playbook: playbooks/webapp.yml
+    ask_credential_on_launch: true
+    ask_inventory_on_launch: true
+    ask_variables_on_launch: true
+    extra_vars:
+      azure_resource_group: "<deployment resource group>"
+    become_enabled: false
+    job_slice_count: 1
+    state: present
+  when:
+    - seed_validated_content
+    - cloud_services_ee is defined
+    - seeded_content_project_azure is defined
+  register: ephemeral_workload_template
+  tags:
+    - templates
+
+- name: Azure web application migration demo
+  ansible.controller.job_template:
+    name: Azure web application migration demo
+    job_type: run
+    execution_environment: "{{ cloud_services_ee.name }}"
+    project: "{{ seeded_content_project_azure.name }}"
+    playbook: playbooks/vmss_migrate.yml
+    ask_credential_on_launch: true
+    ask_inventory_on_launch: true
+    ask_variables_on_launch: true
+    extra_vars:
+      source_resource_group: "<source resource group>"
+      destination_resource_group: "<destination resource group>"
+    become_enabled: false
+    job_slice_count: 1
+    state: present
+  when:
+    - seed_validated_content
+    - cloud_services_ee is defined
+    - seeded_content_project_azure is defined
+  register: ephemeral_workload_template
+  tags:
+    - templates

--- a/roles/controller/tasks/job_templates.yml
+++ b/roles/controller/tasks/job_templates.yml
@@ -3,49 +3,60 @@
   ansible.controller.job_template:
     name: Demo Job Template
     state: absent
-  when: (delete_demo_project is defined) and (delete_demo_project | bool)
+  when:
+    - job_templates.demo.delete_demo_template is defined
+    - job_templates.demo.delete_demo_template
+    - seed_content_lab
   tags:
     - templates
 
 - name: Azure - Create Resource Group
   ansible.controller.job_template:
-    name: lab.azure_roles.create_resource_group
+    name: Azure - Create Resource Group
     inventory: localhost
     playbook: playbook_create_resource_group.yml
-    project: Ansible Cloud Content Lab - Azure Roles
+    project: "{{ content_lab_project_azure }}"
     extra_vars:
       resource_group: "{{ azure_resource_group }}"
       region: "{{ azure_region }}"
     credentials:
-      - Azure Service Principal
+      - "{{ azure_credential.name }}"
+  when:
+    - seed_content_lab
+    - azure_credential is defined
+    - content_lab_project_azure is defined
   tags:
     - templates
 
 - name: Azure - Create VNET
   ansible.controller.job_template:
-    name: lab.azure_roles.create_vnet
+    name: Azure - Create VNET
     inventory: localhost
     playbook: playbook_create_vnet.yml
-    project: Ansible Cloud Content Lab - Azure Roles
+    project: "{{ content_lab_project_azure }}"
     extra_vars:
       resource_group: "{{ azure_resource_group }}"
       region: "{{ azure_region }}"
-      route_table_name: "{{ job_templates.vnet_route_table_name }}"
-      vnet_name: "{{ job_templates.vnet_name }}"
-      vnet_cidr: "{{ job_templates.vnet_cidr }}"
-      subnet_name: "{{ job_templates.subnet_name }}"
-      subnet_cidr: "{{ job_templates.subnet_cidr }}"
+      route_table_name: "{{ job_templates.vnet.vnet_route_table_name }}"
+      vnet_name: "{{ job_templates.vnet.vnet_name }}"
+      vnet_cidr: "{{ job_templates.vnet.vnet_cidr }}"
+      subnet_name: "{{ job_templates.vnet.subnet_name }}"
+      subnet_cidr: "{{ job_templates.vnet.subnet_cidr }}"
     credentials:
-      - Azure Service Principal
+      - "{{ azure_credential.name }}"
+  when:
+    - seed_content_lab
+    - azure_credential is defined
+    - content_lab_project_azure is defined
   tags:
     - templates
 
 - name: Azure - Create RHEL VM
   ansible.controller.job_template:
-    name: lab.azure_roles.create_rhel_vm
+    name: Azure - Create RHEL VM
     inventory: localhost
     playbook: playbook_create_vm.yml
-    project: Ansible Cloud Content Lab - Azure Roles
+    project: "{{ content_lab_project_azure.name }}"
     extra_vars:
       resource_group: "{{ azure_resource_group }}"
       region: "{{ azure_region }}"
@@ -55,27 +66,30 @@
       nic_name: create-rhel-test-nic
       network_sec_group_name: create-rhel-test-sg
       public_ip_name: create-rhel-test-public-ip
-      vnet_name: spoke-1-vnet
-      subnet_name: spoke-1-subnet
+      vnet_name: "{{ job_templates.vnet.vnet_name }}"
+      subnet_name: "{{ job_templates.vnet.subnet_name }}"
       create_public_ip: true
-      ssh_public_key:  "{{ job_templates.ssh_public_key }}"
       admin_user: azureuser
-      admin_password: "{{ job_templates.admin_password }}"
+      admin_password: ansible12345!
       ssh_public_keys:
         - path: "{% raw %}/home/{{ admin_user }}/.ssh/authorized_keys{% endraw %}"
           key_data: "{% raw %}{{ lookup('file', '/home/runner/.ssh/id_rsa_azure_demo.pub') }}{% endraw %}" # Can be populated through a custom credential or variable
     ask_variables_on_launch: true
     credentials:
-      - Azure Service Principal
+      - "{{ azure_credential.name }}"
+  when:
+    - seed_content_lab
+    - azure_credential is defined
+    - content_lab_project_azure is defined
   tags:
     - templates
 
 - name: Azure - Delete RHEL VM
   ansible.controller.job_template:
-    name: lab.azure_roles.delete_rhel_vm
+    name: Azure - Delete RHEL VM
     inventory: localhost
     playbook: playbook_delete_vm.yml
-    project: Ansible Cloud Content Lab - Azure Roles
+    project: "{{ content_lab_project_azure.name }}"
     extra_vars:
       resource_group: "{{ azure_resource_group }}"
       vm_name: rhel9-test
@@ -83,16 +97,20 @@
       network_sec_group_name: "{% raw %}{{ vm_name }}-sg{% endraw %}"
       public_ip_name: "{% raw %}{{ vm_name }}-public-ip{% endraw %}"
     credentials:
-      - Azure Service Principal
+      - "{{ azure_credential.name }}"
+  when:
+    - seed_content_lab
+    - azure_credential is defined
+    - content_lab_project_azure is defined
   tags:
     - templates
 
 - name: Azure - Create Windows Server VM
   ansible.controller.job_template:
-    name: lab.azure_roles.create_windows_vm
+    name: Azure - Create Windows Server VM
     inventory: localhost
     playbook: playbook_create_vm.yml
-    project: Ansible Cloud Content Lab - Azure Roles
+    project: "{{ content_lab_project_azure }}"
     extra_vars:
       resource_group: "{{ azure_resource_group }}"
       region: "{{ azure_region }}"
@@ -101,23 +119,27 @@
       nic_name: create-win-test-nic
       network_sec_group_name: create-win-test-sg
       public_ip_name: create-win-test-public-ip
-      vnet_name: spoke-1-vnet
-      subnet_name: spoke-1-subnet
+      vnet_name: "{{ job_templates.vnet.vnet_name }}"
+      subnet_name: "{{ job_templates.vnet.subnet_name }}"
       create_public_ip: true
       admin_user: azureuser
-      admin_password: "{{ job_templates.admin_password }}"
+      admin_password: ansible12345!
     ask_variables_on_launch: true
     credentials:
-      - Azure Service Principal
+      - "{{ azure_credential.name }}"
+  when:
+    - seed_content_lab
+    - azure_credential is defined
+    - content_lab_project_azure is defined
   tags:
     - templates
 
 - name: Azure - Delete Windows VM
   ansible.controller.job_template:
-    name: lab.azure_roles.delete_windows_vm
+    name: Azure - Delete Windows VM
     inventory: localhost
     playbook: playbook_delete_vm.yml
-    project: Ansible Cloud Content Lab - Azure Roles
+    project: "{{ content_lab_project_azure }}"
     extra_vars:
       resource_group: "{{ azure_resource_group }}"
       vm_name:  win2022-test
@@ -125,30 +147,38 @@
       network_sec_group_name: "{% raw %}{{ vm_name }}-sg{% endraw %}"
       public_ip_name: "{% raw %}{{ vm_name }}-public-ip{% endraw %}"
     credentials:
-      - Azure Service Principal
+      - "{{ azure_credential.name }}"
+  when:
+    - seed_content_lab
+    - azure_credential is defined
+    - content_lab_project_azure is defined
   tags:
     - templates
 
 - name: Azure - Destroy Resource Group
   ansible.controller.job_template:
-    name: lab.azure_roles.delete_resource_group
+    name: Azure - Destroy Resource Group
     inventory: localhost
     playbook: playbook_delete_resource_group.yml
-    project: Ansible Cloud Content Lab - Azure Roles
+    project: "{{ content_lab_project_azure.name }}"
     extra_vars:
       resource_group: "{{ azure_resource_group }}"
       region: "{{ azure_region }}"
     credentials:
-      - Azure Service Principal
+      - "{{ azure_credential.name }}"
+  when:
+    - seed_content_lab
+    - azure_credential is defined
+    - content_lab_project_azure is defined
   tags:
     - templates
 
 - name: Azure - Create Network Peering Demo
   ansible.controller.job_template:
-    name: lab.azure_roles.create_transit_network
+    name: Azure - Create Network Peering Demo
     inventory: localhost
     playbook: playbook_create_transit_network.yml
-    project: Ansible Cloud Content Lab - Azure Roles
+    project: "{{ content_lab_project_azure.name }}"
     extra_vars:
       resource_group: "{{ azure_resource_group }}"
       region: "{{ azure_region }}"
@@ -158,14 +188,18 @@
       ansible_ssh_private_key_file_dest_path: /home/runner/.ssh/id_rsa_azure_demo
     ask_variables_on_launch: true
     credentials:
-      - Azure Service Principal
+      - "{{ azure_credential.name }}"
+  when:
+    - seed_content_lab
+    - azure_credential is defined
+    - content_lab_project_azure is defined
   tags:
     - templates
 
 - name: Azure - Destroy Network Peering Demo
   ansible.controller.job_template:
-    name: lab.azure_roles.delete_transit_network
-    project: Ansible Cloud Content Lab - Azure Roles
+    name: Azure - Destroy Network Peering Demo
+    project: "{{ content_lab_project_azure.name }}"
     playbook: playbook_delete_transit_network.yml
     inventory: localhost
     extra_vars:
@@ -173,32 +207,40 @@
       region: "{{ azure_region }}"
     ask_variables_on_launch: true
     credentials:
-      - Azure Service Principal
+      - "{{ azure_credential.name }}"
+  when:
+    - seed_content_lab
+    - azure_credential is defined
+    - content_lab_project_azure is defined
   tags:
     - templates
 
 - name: Azure - Run DNF Update
   ansible.controller.job_template:
-    name: lab.azure_roles.update_rhel_vms
+    name: Azure - Run DNF Update
     job_type: run
-    project: Ansible Cloud Content Lab - Azure Roles
+    project: "{{ content_lab_project_azure.name }}"
     playbook: playbook_update_rhel_vms.yml
-    inventory: Azure
+    inventory: "{{ azure_inventory.name }}"
     limit: rhel
     credentials:
-      - Azure VM SSH Credential
+      - "{{ azure_vm_credential.name }}"
     become_enabled: true
     job_slice_count: 5
     state: present
+  when:
+    - seed_content_lab
+    - azure_vm_credential is defined
+    - content_lab_project_azure is defined
   tags:
     - templates
 
 - name: Azure - Install Arc Agent
   ansible.controller.job_template:
-    name: lab.azure_roles.arc_install_agent
-    inventory: Azure
+    name: Azure - Install Arc Agent
+    inventory: "{{ azure_inventory.name }}"
     playbook: playbook_install_arc_agent.yml
-    project: Ansible Cloud Content Lab - Azure Roles
+    project: "{{ content_lab_project_azure.name }}"
     extra_vars: 
       resource_group: "{{ azure_resource_group }}"
       region: "{{ azure_region }}"
@@ -207,108 +249,137 @@
       service_principal_id: "{% raw %}{{ lookup('env', 'AZURE_CLIENT_ID') }}{% endraw %}"
       service_principal_secret: "{% raw %}{{ lookup('env', 'AZURE_SECRET') }}{% endraw %}"
     credentials:
-      - Azure VM SSH Credential
-      - Azure Service Principal
+      - "{{ azure_vm_credential.name }}"
+      - "{{ azure_credential.name }}"
     limit: rhel
     become_enabled: true
     ask_inventory_on_launch: true
     ask_limit_on_launch: true
+  when:
+    - seed_content_lab
+    - azure_credential is defined
+    - azure_vm_credential is defined
+    - content_lab_project_azure is defined
   tags:
     - templates
 
 - name: Azure - Enable Arc Extensions
   ansible.controller.job_template:
-    name: lab.azure_roles.arc_enable_extensions
-    inventory: Azure
+    name: Azure - Enable Arc Extensions
+    inventory: "{{ azure_inventory.name }}"
     playbook: playbook_enable_arc_extension.yml
-    project: Ansible Cloud Content Lab - Azure Roles
+    project: "{{ content_lab_project_azure.name }}"
     extra_vars: 
       resource_group: "{{ azure_resource_group }}"
       region: "{{ azure_region }}"
       arc_hosts: "{% raw %}{{ hostvars.values() | selectattr('group_names','contains', 'arc') | map(attribute='inventory_hostname') | list }}{% endraw %}"
       extension: azure_monitor_agent # this name is from the extension variable mapping in the content lab collection
     credentials:
-      - Azure Service Principal
+      - "{{ azure_credential.name }}"
     ask_variables_on_launch: true
+  when:
+    - seed_content_lab
+    - azure_credential is defined
+    - content_lab_project_azure is defined
   tags:
     - templates
 
 - name: Azure - Disable Arc Extensions
   ansible.controller.job_template:
-    name: lab.azure_roles.arc_disable_extensions
-    inventory: Azure
+    name: Azure - Disable Arc Extensions
+    inventory: "{{ azure_inventory.name }}"
     playbook: playbook_disable_arc_extension.yml
-    project: Ansible Cloud Content Lab - Azure Roles
+    project: "{{ content_lab_project_azure.name }}"
     extra_vars: 
       resource_group_name: "{{ azure_resource_group }}"
       region: "{{ azure_region }}"
       arc_hosts: "{% raw %}{{ hostvars.values() | selectattr('group_names','contains', 'arc') | map(attribute='inventory_hostname') | list }}{% endraw %}"
       extension: azure_monitor_agent # this name is from the extension variable mapping in the content lab collection
     credentials:
-      - Azure Service Principal
+      - "{{ azure_credential.name }}"
     ask_variables_on_launch: true
+  when:
+    - seed_content_lab
+    - azure_credential is defined
+    - content_lab_project_azure is defined
   tags:
     - templates
 
 - name: Azure - Replace Log Analytics with Azure Monitor
   ansible.controller.job_template:
-    name: lab.azure_roles.arc_replace_log_analytics_with_azure_monitor
-    inventory: Azure
+    name: Azure - Replace Log Analytics with Azure Monitor
+    inventory: "{{ azure_inventory.name }}"
     playbook: playbook_replace_log_analytics_with_arc_linux.yml
-    project: Ansible Cloud Content Lab - Azure Roles
+    project: "{{ content_lab_project_azure.name }}"
     extra_vars:
       region: "{{ azure_region }}"
       resource_group: "{{ azure_resource_group }}"
       linux_hosts: "{% raw %}{{ hostvars.values() | selectattr('group_names','contains', 'arc') | map(attribute='inventory_hostname') | list }}{% endraw %}"
     credentials:
-      - Azure Service Principal
+      - "{{ azure_credential.name }}"
+  when:
+    - seed_content_lab
+    - azure_credential is defined
+    - content_lab_project_azure is defined
   tags:
     - templates
 
 - name: Azure - Create Log Analytics Workspace
   ansible.controller.job_template:
-    name: lab.azure_roles.create_log_analytics_workspace
+    name: Azure - Create Log Analytics Workspace
     inventory: localhost
     playbook: playbook_create_log_analytics_workspace.yml
-    project: Ansible Cloud Content Lab - Azure Roles
+    project: "{{ content_lab_project_azure.name }}"
     credentials:
-      - Azure VM SSH Credential
+      - "{{ azure_vm_credential.name }}"
     extra_vars:
       resource_group: "{{ azure_resource_group }}"
-      workspace_name: "{{ job_templates.log_ws_name }}"
+      workspace_name: "{{ job_templates.log_analytics.ws_name }}"
     limit: rhel
+  when:
+    - seed_content_lab
+    - azure_vm_credential is defined
+    - content_lab_project_azure is defined
   tags:
     - templates
 
 - name: Azure - Install Log Analytics Agent
   ansible.controller.job_template:
-    name: lab.azure_roles.log_analytics_install_agent
-    inventory: Azure
+    name: Azure - Install Log Analytics Agent
+    inventory: "{{ azure_inventory.name }}"
     playbook: playbook_install_log_analytics_agent.yml
-    project: Ansible Cloud Content Lab - Azure Roles
+    project: "{{ content_lab_project_azure.name }}"
     credentials:
-      - Azure VM SSH Credential
+      - "{{ azure_vm_credential.name }}"
     extra_vars:
       resource_group: "{{ azure_resource_group }}"
-      workspace_name: log-ws
+      workspace_name: "{{ job_templates.log_analytics.ws_name }}"
     become_enabled: true
     limit: rhel
     ask_inventory_on_launch: true
     ask_limit_on_launch: true
+  when:
+    - seed_content_lab
+    - azure_vm_credential is defined
+    - content_lab_project_azure is defined
   tags:
     - templates
 
 - name: Azure - Uninstall Log Analytics Agent
   ansible.controller.job_template:
-    name: lab.azure_roles.log_analytics_uninstall_agent
-    inventory: Azure
+    name: Azure - Uninstall Log Analytics Agent
+    inventory: "{{ azure_inventory.name }}"
     playbook: playbook_uninstall_log_analytics_agent.yml
-    project: Ansible Cloud Content Lab - Azure Roles
+    project: "{{ content_lab_project_azure.name }}"
     credentials:
-      - Azure VM SSH Credential
+      - "{{ azure_vm_credential.name }}"
     become_enabled: true
     ask_inventory_on_launch: true
     ask_limit_on_launch: true
+  when:
+    - seed_content_lab
+    - azure_vm_credential is defined
+    - content_lab_project_azure is defined
   tags:
     - templates
 
@@ -316,15 +387,21 @@
   ansible.controller.job_template:
     name: Azure Demos - Ephemeral Workload Test
     job_type: run
-    project: Ansible - Azure Demo
+    project: "{{ content_lab_project_demo.name }}"
     playbook: project/emphemeral_workload_test.yml
     inventory: localhost
     credentials:
-      - Ansible Automation Controller
-      - Azure Service Principal
-      - Azure VM SSH Credential
+      - "{{ controller_credential.name }}"
+      - "{{ azure_credential.name }}"
+      - "{{ azure_vm_credential.name }}"
     become_enabled: true
     job_slice_count: 1
     state: present
+  when:
+    - seed_content_lab
+    - azure_credential is defined
+    - azure_vm_credential is defined
+    - controller_credential is defined
+    - content_lab_project_demo is defined
   tags:
     - templates

--- a/roles/controller/tasks/job_templates.yml
+++ b/roles/controller/tasks/job_templates.yml
@@ -13,7 +13,7 @@
 - name: Content Lab - Azure - Create Resource Group
   ansible.controller.job_template:
     name: Content Lab - Azure - Create Resource Group
-    inventory: localhost
+    inventory: "{{ inventories.localhost.name }}"
     playbook: playbook_create_resource_group.yml
     project: "{{ projects.azure_lab_roles.name }}"
     extra_vars:
@@ -27,13 +27,15 @@
     - credentials.azure_service_principal.name is defined
     - content_lab_project_azure is defined
     - projects.azure_lab_roles.name is defined
+    - localhost_inventory is defined
+    - inventories.localhost.name is defined
   tags:
     - templates
 
 - name: Content Lab - Azure - Create VNET
   ansible.controller.job_template:
     name: Content Lab - Azure - Create VNET
-    inventory: localhost
+    inventory: "{{ inventories.localhost.name }}"
     playbook: playbook_create_vnet.yml
     project: "{{ projects.azure_lab_roles.name }}"
     extra_vars:
@@ -52,13 +54,15 @@
     - credentials.azure_service_principal.name is defined
     - content_lab_project_azure is defined
     - projects.azure_lab_roles.name is defined
+    - localhost_inventory is defined
+    - inventories.localhost.name is defined
   tags:
     - templates
 
 - name: Content Lab - Azure - Create RHEL VM
   ansible.controller.job_template:
     name: Content Lab - Azure - Create RHEL VM
-    inventory: localhost
+    inventory: "{{ inventories.localhost.name }}"
     playbook: playbook_create_vm.yml
     project: "{{ projects.azure_lab_roles.name }}"
     extra_vars:
@@ -87,6 +91,8 @@
     - credentials.azure_service_principal.name is defined
     - content_lab_project_azure is defined
     - projects.azure_lab_roles.name is defined
+    - localhost_inventory is defined
+    - inventories.localhost.name is defined
   register: create_rhel_vm_template
   tags:
     - templates
@@ -94,7 +100,7 @@
 - name: Content Lab - Azure - Delete RHEL VM
   ansible.controller.job_template:
     name: Content Lab - Azure - Delete RHEL VM
-    inventory: localhost
+    inventory: "{{ inventories.localhost.name }}"
     playbook: playbook_delete_vm.yml
     project: "{{ projects.azure_lab_roles.name }}"
     extra_vars:
@@ -111,6 +117,8 @@
     - credentials.azure_service_principal.name is defined
     - content_lab_project_azure is defined
     - projects.azure_lab_roles.name is defined
+    - localhost_inventory is defined
+    - inventories.localhost.name is defined
   register: delete_rhel_vm_template
   tags:
     - templates
@@ -118,7 +126,7 @@
 - name: Content Lab - Azure - Create Windows Server VM
   ansible.controller.job_template:
     name: Content Lab - Azure - Create Windows Server VM
-    inventory: localhost
+    inventory: "{{ inventories.localhost.name }}"
     playbook: playbook_create_vm.yml
     project: "{{ projects.azure_lab_roles.name }}"
     extra_vars:
@@ -143,6 +151,8 @@
     - credentials.azure_service_principal.name is defined
     - content_lab_project_azure is defined
     - projects.azure_lab_roles.name is defined
+    - localhost_inventory is defined
+    - inventories.localhost.name is defined
   register: create_windows_vm_template
   tags:
     - templates
@@ -150,7 +160,7 @@
 - name: Content Lab - Azure - Delete Windows VM
   ansible.controller.job_template:
     name: Content Lab - Azure - Delete Windows VM
-    inventory: localhost
+    inventory: "{{ inventories.localhost.name }}"
     playbook: playbook_delete_vm.yml
     project: "{{ projects.azure_lab_roles.name }}"
     extra_vars:
@@ -167,6 +177,8 @@
     - credentials.azure_service_principal.name is defined
     - content_lab_project_azure is defined
     - projects.azure_lab_roles.name is defined
+    - localhost_inventory is defined
+    - inventories.localhost.name is defined
   register: delete_windows_vm_template
   tags:
     - templates
@@ -174,7 +186,7 @@
 - name: Content Lab - Azure - Delete Resource Group
   ansible.controller.job_template:
     name: Content Lab - Azure - Delete Resource Group
-    inventory: localhost
+    inventory: "{{ inventories.localhost.name }}"
     playbook: playbook_delete_resource_group.yml
     project: "{{ projects.azure_lab_roles.name }}"
     extra_vars:
@@ -188,6 +200,8 @@
     - credentials.azure_service_principal.name is defined
     - content_lab_project_azure is defined
     - projects.azure_lab_roles.name is defined
+    - localhost_inventory is defined
+    - inventories.localhost.name is defined
   register: delete_resource_group_template
   tags:
     - templates
@@ -195,7 +209,7 @@
 - name: Content Lab - Azure - Create Network Peering Demo
   ansible.controller.job_template:
     name: Content Lab - Azure - Create Network Peering Demo
-    inventory: localhost
+    inventory: "{{ inventories.localhost.name }}"
     playbook: playbook_create_transit_network.yml
     project: "{{ projects.azure_lab_roles.name }}"
     extra_vars:
@@ -214,6 +228,8 @@
     - credentials.azure_service_principal.name is defined
     - content_lab_project_azure is defined
     - projects.azure_lab_roles.name is defined
+    - localhost_inventory is defined
+    - inventories.localhost.name is defined
   register: create_network_peering_demo_template
   tags:
     - templates
@@ -223,7 +239,7 @@
     name: Content Lab - Azure - Delete Network Peering Demo
     project: "{{ projects.azure_lab_roles.name }}"
     playbook: playbook_delete_transit_network.yml
-    inventory: localhost
+    inventory: "{{ inventories.localhost.name }}"
     extra_vars:
       resource_group: "{{ azure_resource_group }}"
       region: "{{ azure_region }}"
@@ -236,6 +252,8 @@
     - credentials.azure_service_principal.name is defined
     - content_lab_project_azure is defined
     - projects.azure_lab_roles.name is defined
+    - localhost_inventory is defined
+    - inventories.localhost.name is defined
   register: delete_network_peering_demo_template
   tags:
     - templates
@@ -246,7 +264,7 @@
     job_type: run
     project: "{{ projects.azure_lab_roles.name }}"
     playbook: playbook_update_rhel_vms.yml
-    inventory: "{{ azure_inventory.name }}"
+    inventory: "{{ inventories.azure.name }}"
     limit: rhel
     credentials:
       - "{{ credentials.ssh.name }}"
@@ -259,6 +277,8 @@
     - credentials.ssh.name is defined
     - content_lab_project_azure is defined
     - projects.azure_lab_roles.name is defined
+    - azure_inventory is defined
+    - inventories.azure.name is defined
   register: rhel_vm_update_template
   tags:
     - templates
@@ -266,7 +286,7 @@
 - name: Content Lab - Azure - Install Arc Agent
   ansible.controller.job_template:
     name: Content Lab - Azure - Install Arc Agent
-    inventory: "{{ azure_inventory.name }}"
+    inventory: "{{ inventories.azure.name }}"
     playbook: playbook_install_arc_agent.yml
     project: "{{ projects.azure_lab_roles.name }}"
     extra_vars: 
@@ -291,6 +311,8 @@
     - credentials.ssh.name is defined
     - content_lab_project_azure is defined
     - projects.azure_lab_roles.name is defined
+    - azure_inventory is defined
+    - inventories.azure.name is defined
   register: install_arc_agent_template
   tags:
     - templates
@@ -298,7 +320,7 @@
 - name: Content Lab - Azure - Enable Arc Extensions
   ansible.controller.job_template:
     name: Content Lab - Azure - Enable Arc Extensions
-    inventory: "{{ azure_inventory.name }}"
+    inventory: "{{ inventories.azure.name }}"
     playbook: playbook_enable_arc_extension.yml
     project: "{{ projects.azure_lab_roles.name }}"
     extra_vars: 
@@ -315,6 +337,8 @@
     - credentials.azure_service_principal.name is defined
     - content_lab_project_azure is defined
     - projects.azure_lab_roles.name is defined
+    - azure_inventory is defined
+    - inventories.azure.name is defined
   register: enable_arc_extensions_template
   tags:
     - templates
@@ -322,7 +346,7 @@
 - name: Content Lab - Azure - Disable Arc Extensions
   ansible.controller.job_template:
     name: Content Lab - Azure - Disable Arc Extensions
-    inventory: "{{ azure_inventory.name }}"
+    inventory: "{{ inventories.azure.name }}"
     playbook: playbook_disable_arc_extension.yml
     project: "{{ projects.azure_lab_roles.name }}"
     extra_vars: 
@@ -339,6 +363,8 @@
     - credentials.azure_service_principal.name is defined
     - content_lab_project_azure is defined
     - projects.azure_lab_roles.name is defined
+    - azure_inventory is defined
+    - inventories.azure.name is defined
   register: disable_arc_extensions_template
   tags:
     - templates
@@ -346,7 +372,7 @@
 - name: Content Lab - Azure - Replace Log Analytics with Azure Monitor
   ansible.controller.job_template:
     name: Content Lab - Azure - Replace Log Analytics with Azure Monitor
-    inventory: "{{ azure_inventory.name }}"
+    inventory: "{{ inventories.azure.name }}"
     playbook: playbook_replace_log_analytics_with_arc_linux.yml
     project: "{{ projects.azure_lab_roles.name }}"
     extra_vars:
@@ -361,6 +387,8 @@
     - credentials.azure_service_principal.name is defined
     - content_lab_project_azure is defined
     - projects.azure_lab_roles.name is defined
+    - azure_inventory is defined
+    - inventories.azure.name is defined
   register: replace_log_analytics_with_azure_monitor_template
   tags:
     - templates
@@ -368,7 +396,7 @@
 - name: Content Lab - Azure - Create Log Analytics Workspace
   ansible.controller.job_template:
     name: Azure - Create Log Analytics Workspace
-    inventory: localhost
+    inventory: "{{ inventories.localhost.name }}"
     playbook: playbook_create_log_analytics_workspace.yml
     project: "{{ projects.azure_lab_roles.name }}"
     credentials:
@@ -383,6 +411,8 @@
     - credentials.ssh.name is defined
     - content_lab_project_azure is defined
     - projects.azure_lab_roles.name is defined
+    - localhost_inventory is defined
+    - inventories.localhost.name is defined
   register: create_log_analytics_workspace_template
   tags:
     - templates
@@ -390,7 +420,7 @@
 - name: Content Lab - Azure - Install Log Analytics Agent
   ansible.controller.job_template:
     name: Azure - Install Log Analytics Agent
-    inventory: "{{ azure_inventory.name }}"
+    inventory: "{{ inventories.azure.name }}"
     playbook: playbook_install_log_analytics_agent.yml
     project: "{{ projects.azure_lab_roles.name }}"
     credentials:
@@ -408,6 +438,8 @@
     - credentials.ssh.name is defined
     - content_lab_project_azure is defined
     - projects.azure_lab_roles.name is defined
+    - azure_inventory is defined
+    - inventories.azure.name is defined
   register: install_log_analytics_agent_template
   tags:
     - templates
@@ -415,7 +447,7 @@
 - name: Content Lab - Azure - Uninstall Log Analytics Agent
   ansible.controller.job_template:
     name: Content Lab - Azure - Uninstall Log Analytics Agent
-    inventory: "{{ azure_inventory.name }}"
+    inventory: "{{ inventories.azure.name }}"
     playbook: playbook_uninstall_log_analytics_agent.yml
     project: "{{ projects.azure_lab_roles.name }}"
     credentials:
@@ -429,6 +461,8 @@
     - credentials.ssh.name is defined
     - content_lab_project_azure is defined
     - projects.azure_lab_roles.name is defined
+    - azure_inventory is defined
+    - inventories.azure.name is defined
   register: uninstall_log_analytics_agent_template
   tags:
     - templates
@@ -439,7 +473,7 @@
     job_type: run
     project: "{{ projects.azure_demo_project.name }}"
     playbook: project/emphemeral_workload_test.yml
-    inventory: localhost
+    inventory: "{{ inventories.localhost.name }}"
     credentials:
       - "{{ credentials.azure_service_principal.name }}"
       - "{{ credentials.controller.name }}"
@@ -457,6 +491,8 @@
     - credentials.controller.name is defined
     - content_lab_project_demo is defined
     - projects.azure_demo_project.name is defined
+    - localhost_inventory is defined
+    - inventories.localhost.name is defined
   register: ephemeral_workload_template
   tags:
     - templates
@@ -465,7 +501,7 @@
   ansible.controller.job_template:
     name: Validated Content - Azure web application deployment demo
     job_type: run
-    execution_environment: "{{ execution_environments.cloud_services_ee_name }}"
+    execution_environment: "{{ execution_environments.cloud_services.name }}"
     project: "{{ projects.azure_seeded_content.name }}"
     playbook: playbooks/webapp.yml
     ask_credential_on_launch: true
@@ -479,7 +515,7 @@
   when:
     - seed_validated_content
     - cloud_services_ee is defined
-    - execution_environments.cloud_services_ee_name is defined
+    - execution_environments.cloud_services.name is defined
     - seeded_content_project_azure is defined
     - projects.azure_seeded_content.name is defined
   register: ephemeral_workload_template
@@ -490,7 +526,7 @@
   ansible.controller.job_template:
     name: Validated Content - Azure web application migration demo
     job_type: run
-    execution_environment: "{{ execution_environments.cloud_services_ee_name }}"
+    execution_environment: "{{ execution_environments.cloud_services.name }}"
     project: "{{ projects.azure_seeded_content.name }}"
     playbook: playbooks/vmss_migrate.yml
     ask_credential_on_launch: true
@@ -505,7 +541,7 @@
   when:
     - seed_validated_content
     - cloud_services_ee is defined
-    - execution_environments.cloud_services_ee_name is defined
+    - execution_environments.cloud_services.name is defined
     - seeded_content_project_azure is defined
     - projects.azure_seeded_content.name is defined
   register: ephemeral_workload_template

--- a/roles/controller/tasks/job_templates.yml
+++ b/roles/controller/tasks/job_templates.yml
@@ -6,7 +6,7 @@
   when:
     - job_templates.demo.delete_demo_template is defined
     - job_templates.demo.delete_demo_template
-    - seed_lab_content
+    - (seed_lab_content | bool)
   tags:
     - templates
 
@@ -22,7 +22,7 @@
     credentials:
       - "{{ credentials.azure_service_principal.name }}"
   when:
-    - seed_lab_content
+    - (seed_lab_content | bool)
     - azure_credential is defined
     - credentials.azure_service_principal.name is defined
     - content_lab_project_azure is defined
@@ -49,7 +49,7 @@
     credentials:
       - "{{ credentials.azure_service_principal.name }}"
   when:
-    - seed_lab_content
+    - (seed_lab_content | bool)
     - azure_credential is defined
     - credentials.azure_service_principal.name is defined
     - content_lab_project_azure is defined
@@ -86,7 +86,7 @@
     credentials:
       - "{{ credentials.azure_service_principal.name }}"
   when:
-    - seed_lab_content
+    - (seed_lab_content | bool)
     - azure_credential is defined
     - credentials.azure_service_principal.name is defined
     - content_lab_project_azure is defined
@@ -112,7 +112,7 @@
     credentials:
       - "{{ credentials.azure_service_principal.name }}"
   when:
-    - seed_lab_content
+    - (seed_lab_content | bool)
     - azure_credential is defined
     - credentials.azure_service_principal.name is defined
     - content_lab_project_azure is defined
@@ -146,7 +146,7 @@
     credentials:
       - "{{ credentials.azure_service_principal.name }}"
   when:
-    - seed_lab_content
+    - (seed_lab_content | bool)
     - azure_credential is defined
     - credentials.azure_service_principal.name is defined
     - content_lab_project_azure is defined
@@ -172,7 +172,7 @@
     credentials:
       - "{{ credentials.azure_service_principal.name }}"
   when:
-    - seed_lab_content
+    - (seed_lab_content | bool)
     - azure_credential is defined
     - credentials.azure_service_principal.name is defined
     - content_lab_project_azure is defined
@@ -195,7 +195,7 @@
     credentials:
       - "{{ credentials.azure_service_principal.name }}"
   when:
-    - seed_lab_content
+    - (seed_lab_content | bool)
     - azure_credential is defined
     - credentials.azure_service_principal.name is defined
     - content_lab_project_azure is defined
@@ -223,7 +223,7 @@
     credentials:
       - "{{ credentials.azure_service_principal.name }}"
   when:
-    - seed_lab_content
+    - (seed_lab_content | bool)
     - azure_credential is defined
     - credentials.azure_service_principal.name is defined
     - content_lab_project_azure is defined
@@ -247,7 +247,7 @@
     credentials:
       - "{{ credentials.azure_service_principal.name }}"
   when:
-    - seed_lab_content
+    - (seed_lab_content | bool)
     - azure_credential is defined
     - credentials.azure_service_principal.name is defined
     - content_lab_project_azure is defined
@@ -272,7 +272,7 @@
     job_slice_count: 5
     state: present
   when:
-    - seed_lab_content
+    - (seed_lab_content | bool)
     - vm_credential is defined
     - credentials.ssh.name is defined
     - content_lab_project_azure is defined
@@ -304,7 +304,7 @@
     ask_inventory_on_launch: true
     ask_limit_on_launch: true
   when:
-    - seed_lab_content
+    - (seed_lab_content | bool)
     - job_templates.install_arc_agent.name is defined
     - azure_credential is defined
     - credentials.azure_service_principal.name is defined
@@ -333,7 +333,7 @@
       - "{{ credentials.azure_service_principal.name }}"
     ask_variables_on_launch: true
   when:
-    - seed_lab_content
+    - (seed_lab_content | bool)
     - azure_credential is defined
     - credentials.azure_service_principal.name is defined
     - content_lab_project_azure is defined
@@ -359,7 +359,7 @@
       - "{{ credentials.azure_service_principal.name }}"
     ask_variables_on_launch: true
   when:
-    - seed_lab_content
+    - (seed_lab_content | bool)
     - azure_credential is defined
     - credentials.azure_service_principal.name is defined
     - content_lab_project_azure is defined
@@ -383,7 +383,7 @@
     credentials:
       - "{{ credentials.azure_service_principal.name }}"
   when:
-    - seed_lab_content
+    - (seed_lab_content | bool)
     - job_templates.replace_log_analytics_with_azure_monitor.name is defined
     - azure_credential is defined
     - credentials.azure_service_principal.name is defined
@@ -408,7 +408,7 @@
       workspace_name: "{{ job_templates.create_log_analytics_ws.ws_name }}"
     limit: rhel
   when:
-    - seed_lab_content
+    - (seed_lab_content | bool)
     - job_templates.create_log_analytics_ws.name is defined
     - job_templates.create_log_analytics_ws.ws_name is defined
     - vm_credential is defined
@@ -437,7 +437,7 @@
     ask_inventory_on_launch: true
     ask_limit_on_launch: true
   when:
-    - seed_lab_content
+    - (seed_lab_content | bool)
     - job_templates.install_log_analytics.name is defined
     - job_templates.create_log_analytics_ws.ws_name is defined
     - vm_credential is defined
@@ -462,7 +462,7 @@
     ask_inventory_on_launch: true
     ask_limit_on_launch: true
   when:
-    - seed_lab_content
+    - (seed_lab_content | bool)
     - job_templates.uninstall_log_analytics.name is defined
     - vm_credential is defined
     - credentials.ssh.name is defined
@@ -489,7 +489,7 @@
     job_slice_count: 1
     state: present
   when:
-    - seed_lab_content
+    - (seed_lab_content | bool)
     - azure_credential is defined
     - credentials.azure_service_principal.name is defined
     - vm_credential is defined
@@ -520,7 +520,7 @@
     job_slice_count: 1
     state: present
   when:
-    - seed_validated_content
+    - (seed_validated_content | bool)
     - cloud_services_ee is defined
     - execution_environments.cloud_services.name is defined
     - seeded_content_project_azure is defined
@@ -546,7 +546,7 @@
     job_slice_count: 1
     state: present
   when:
-    - seed_validated_content
+    - (seed_validated_content | bool)
     - cloud_services_ee is defined
     - execution_environments.cloud_services.name is defined
     - seeded_content_project_azure is defined

--- a/roles/controller/tasks/job_templates.yml
+++ b/roles/controller/tasks/job_templates.yml
@@ -34,7 +34,7 @@
 
 - name: Content Lab - Azure - Create VNET
   ansible.controller.job_template:
-    name: Content Lab - Azure - Create VNET
+    name: "{{ job_templates.vnet.name }}"
     inventory: "{{ inventories.localhost.name }}"
     playbook: playbook_create_vnet.yml
     project: "{{ projects.azure_lab_roles.name }}"
@@ -61,7 +61,7 @@
 
 - name: Content Lab - Azure - Create RHEL VM
   ansible.controller.job_template:
-    name: Content Lab - Azure - Create RHEL VM
+    name: "{{ job_templates.create_rhel_vm.name }}"
     inventory: "{{ inventories.localhost.name }}"
     playbook: playbook_create_vm.yml
     project: "{{ projects.azure_lab_roles.name }}"
@@ -99,7 +99,7 @@
 
 - name: Content Lab - Azure - Delete RHEL VM
   ansible.controller.job_template:
-    name: Content Lab - Azure - Delete RHEL VM
+    name: "{{ job_templates.delete_rhel_vm.name }}"
     inventory: "{{ inventories.localhost.name }}"
     playbook: playbook_delete_vm.yml
     project: "{{ projects.azure_lab_roles.name }}"
@@ -260,7 +260,7 @@
 
 - name: Content Lab - Azure - Run DNF Update
   ansible.controller.job_template:
-    name: Content Lab - Azure - Run DNF Update
+    name: "{{ job_templates.dnf_update.name }}"
     job_type: run
     project: "{{ projects.azure_lab_roles.name }}"
     playbook: playbook_update_rhel_vms.yml
@@ -285,7 +285,7 @@
 
 - name: Content Lab - Azure - Install Arc Agent
   ansible.controller.job_template:
-    name: Content Lab - Azure - Install Arc Agent
+    name: "{{ job_templates.install_arc_agent.name }}"
     inventory: "{{ inventories.azure.name }}"
     playbook: playbook_install_arc_agent.yml
     project: "{{ projects.azure_lab_roles.name }}"
@@ -305,6 +305,7 @@
     ask_limit_on_launch: true
   when:
     - seed_lab_content
+    - job_templates.install_arc_agent.name is defined
     - azure_credential is defined
     - credentials.azure_service_principal.name is defined
     - vm_credential is defined
@@ -371,7 +372,7 @@
 
 - name: Content Lab - Azure - Replace Log Analytics with Azure Monitor
   ansible.controller.job_template:
-    name: Content Lab - Azure - Replace Log Analytics with Azure Monitor
+    name: "{{ job_templates.replace_log_analytics_with_azure_monitor.name }}"
     inventory: "{{ inventories.azure.name }}"
     playbook: playbook_replace_log_analytics_with_arc_linux.yml
     project: "{{ projects.azure_lab_roles.name }}"
@@ -383,6 +384,7 @@
       - "{{ credentials.azure_service_principal.name }}"
   when:
     - seed_lab_content
+    - job_templates.replace_log_analytics_with_azure_monitor.name is defined
     - azure_credential is defined
     - credentials.azure_service_principal.name is defined
     - content_lab_project_azure is defined
@@ -395,7 +397,7 @@
 
 - name: Content Lab - Azure - Create Log Analytics Workspace
   ansible.controller.job_template:
-    name: Azure - Create Log Analytics Workspace
+    name: "{{ job_templates.create_log_analytics_ws.name }}"
     inventory: "{{ inventories.localhost.name }}"
     playbook: playbook_create_log_analytics_workspace.yml
     project: "{{ projects.azure_lab_roles.name }}"
@@ -403,10 +405,12 @@
       - "{{ credentials.ssh.name }}"
     extra_vars:
       resource_group: "{{ azure_resource_group }}"
-      workspace_name: "{{ job_templates.log_analytics.ws_name }}"
+      workspace_name: "{{ job_templates.create_log_analytics_ws.ws_name }}"
     limit: rhel
   when:
     - seed_lab_content
+    - job_templates.create_log_analytics_ws.name is defined
+    - job_templates.create_log_analytics_ws.ws_name is defined
     - vm_credential is defined
     - credentials.ssh.name is defined
     - content_lab_project_azure is defined
@@ -419,7 +423,7 @@
 
 - name: Content Lab - Azure - Install Log Analytics Agent
   ansible.controller.job_template:
-    name: Azure - Install Log Analytics Agent
+    name: "{{ job_templates.install_log_analytics.name }}"
     inventory: "{{ inventories.azure.name }}"
     playbook: playbook_install_log_analytics_agent.yml
     project: "{{ projects.azure_lab_roles.name }}"
@@ -427,13 +431,15 @@
       - "{{ credentials.ssh.name }}"
     extra_vars:
       resource_group: "{{ azure_resource_group }}"
-      workspace_name: "{{ job_templates.log_analytics.ws_name }}"
+      workspace_name: "{{ job_templates.create_log_analytics_ws.ws_name }}"
     become_enabled: true
     limit: rhel
     ask_inventory_on_launch: true
     ask_limit_on_launch: true
   when:
     - seed_lab_content
+    - job_templates.install_log_analytics.name is defined
+    - job_templates.create_log_analytics_ws.ws_name is defined
     - vm_credential is defined
     - credentials.ssh.name is defined
     - content_lab_project_azure is defined
@@ -446,7 +452,7 @@
 
 - name: Content Lab - Azure - Uninstall Log Analytics Agent
   ansible.controller.job_template:
-    name: Content Lab - Azure - Uninstall Log Analytics Agent
+    name: "{{ job_templates.uninstall_log_analytics.name }}"
     inventory: "{{ inventories.azure.name }}"
     playbook: playbook_uninstall_log_analytics_agent.yml
     project: "{{ projects.azure_lab_roles.name }}"
@@ -457,6 +463,7 @@
     ask_limit_on_launch: true
   when:
     - seed_lab_content
+    - job_templates.uninstall_log_analytics.name is defined
     - vm_credential is defined
     - credentials.ssh.name is defined
     - content_lab_project_azure is defined

--- a/roles/controller/tasks/job_templates.yml
+++ b/roles/controller/tasks/job_templates.yml
@@ -6,13 +6,13 @@
   when:
     - job_templates.demo.delete_demo_template is defined
     - job_templates.demo.delete_demo_template
-    - seed_content_lab
+    - seed_lab_content
   tags:
     - templates
 
-- name: Azure - Create Resource Group
+- name: Content Lab - Azure - Create Resource Group
   ansible.controller.job_template:
-    name: Azure - Create Resource Group
+    name: Content Lab - Azure - Create Resource Group
     inventory: localhost
     playbook: playbook_create_resource_group.yml
     project: "{{ content_lab_project_azure }}"
@@ -20,17 +20,18 @@
       resource_group: "{{ azure_resource_group }}"
       region: "{{ azure_region }}"
     credentials:
-      - "{{ azure_credential.name }}"
+      - "{{ credentials.azure_service_principal.name }}"
   when:
-    - seed_content_lab
+    - seed_lab_content
     - azure_credential is defined
+    - credentials.azure_service_principal.name is defined
     - content_lab_project_azure is defined
   tags:
     - templates
 
-- name: Azure - Create VNET
+- name: Content Lab - Azure - Create VNET
   ansible.controller.job_template:
-    name: Azure - Create VNET
+    name: Content Lab - Azure - Create VNET
     inventory: localhost
     playbook: playbook_create_vnet.yml
     project: "{{ content_lab_project_azure }}"
@@ -43,17 +44,18 @@
       subnet_name: "{{ job_templates.vnet.subnet_name }}"
       subnet_cidr: "{{ job_templates.vnet.subnet_cidr }}"
     credentials:
-      - "{{ azure_credential.name }}"
+      - "{{ credentials.azure_service_principal.name }}"
   when:
-    - seed_content_lab
+    - seed_lab_content
     - azure_credential is defined
+    - credentials.azure_service_principal.name is defined
     - content_lab_project_azure is defined
   tags:
     - templates
 
-- name: Azure - Create RHEL VM
+- name: Content Lab - Azure - Create RHEL VM
   ansible.controller.job_template:
-    name: Azure - Create RHEL VM
+    name: Content Lab - Azure - Create RHEL VM
     inventory: localhost
     playbook: playbook_create_vm.yml
     project: "{{ content_lab_project_azure.name }}"
@@ -76,18 +78,19 @@
           key_data: "{% raw %}{{ lookup('file', '/home/runner/.ssh/id_rsa_azure_demo.pub') }}{% endraw %}" # Can be populated through a custom credential or variable
     ask_variables_on_launch: true
     credentials:
-      - "{{ azure_credential.name }}"
+      - "{{ credentials.azure_service_principal.name }}"
   when:
-    - seed_content_lab
+    - seed_lab_content
     - azure_credential is defined
+    - credentials.azure_service_principal.name is defined
     - content_lab_project_azure is defined
   register: create_rhel_vm_template
   tags:
     - templates
 
-- name: Azure - Delete RHEL VM
+- name: Content Lab - Azure - Delete RHEL VM
   ansible.controller.job_template:
-    name: Azure - Delete RHEL VM
+    name: Content Lab - Azure - Delete RHEL VM
     inventory: localhost
     playbook: playbook_delete_vm.yml
     project: "{{ content_lab_project_azure.name }}"
@@ -98,18 +101,19 @@
       network_sec_group_name: "{% raw %}{{ vm_name }}-sg{% endraw %}"
       public_ip_name: "{% raw %}{{ vm_name }}-public-ip{% endraw %}"
     credentials:
-      - "{{ azure_credential.name }}"
+      - "{{ credentials.azure_service_principal.name }}"
   when:
-    - seed_content_lab
+    - seed_lab_content
     - azure_credential is defined
+    - credentials.azure_service_principal.name is defined
     - content_lab_project_azure is defined
   register: delete_rhel_vm_template
   tags:
     - templates
 
-- name: Azure - Create Windows Server VM
+- name: Content Lab - Azure - Create Windows Server VM
   ansible.controller.job_template:
-    name: Azure - Create Windows Server VM
+    name: Content Lab - Azure - Create Windows Server VM
     inventory: localhost
     playbook: playbook_create_vm.yml
     project: "{{ content_lab_project_azure }}"
@@ -128,18 +132,19 @@
       admin_password: ansible12345!
     ask_variables_on_launch: true
     credentials:
-      - "{{ azure_credential.name }}"
+      - "{{ credentials.azure_service_principal.name }}"
   when:
-    - seed_content_lab
+    - seed_lab_content
     - azure_credential is defined
+    - credentials.azure_service_principal.name is defined
     - content_lab_project_azure is defined
   register: create_windows_vm_template
   tags:
     - templates
 
-- name: Azure - Delete Windows VM
+- name: Content Lab - Azure - Delete Windows VM
   ansible.controller.job_template:
-    name: Azure - Delete Windows VM
+    name: Content Lab - Azure - Delete Windows VM
     inventory: localhost
     playbook: playbook_delete_vm.yml
     project: "{{ content_lab_project_azure }}"
@@ -150,18 +155,19 @@
       network_sec_group_name: "{% raw %}{{ vm_name }}-sg{% endraw %}"
       public_ip_name: "{% raw %}{{ vm_name }}-public-ip{% endraw %}"
     credentials:
-      - "{{ azure_credential.name }}"
+      - "{{ credentials.azure_service_principal.name }}"
   when:
-    - seed_content_lab
+    - seed_lab_content
     - azure_credential is defined
+    - credentials.azure_service_principal.name is defined
     - content_lab_project_azure is defined
   register: delete_windows_vm_template
   tags:
     - templates
 
-- name: Azure - Delete Resource Group
+- name: Content Lab - Azure - Delete Resource Group
   ansible.controller.job_template:
-    name: Azure - Delete Resource Group
+    name: Content Lab - Azure - Delete Resource Group
     inventory: localhost
     playbook: playbook_delete_resource_group.yml
     project: "{{ content_lab_project_azure.name }}"
@@ -169,18 +175,19 @@
       resource_group: "{{ azure_resource_group }}"
       region: "{{ azure_region }}"
     credentials:
-      - "{{ azure_credential.name }}"
+      - "{{ credentials.azure_service_principal.name }}"
   when:
-    - seed_content_lab
+    - seed_lab_content
     - azure_credential is defined
+    - credentials.azure_service_principal.name is defined
     - content_lab_project_azure is defined
   register: delete_resource_group_template
   tags:
     - templates
 
-- name: Azure - Create Network Peering Demo
+- name: Content Lab - Azure - Create Network Peering Demo
   ansible.controller.job_template:
-    name: Azure - Create Network Peering Demo
+    name: Content Lab - Azure - Create Network Peering Demo
     inventory: localhost
     playbook: playbook_create_transit_network.yml
     project: "{{ content_lab_project_azure.name }}"
@@ -193,18 +200,19 @@
       ansible_ssh_private_key_file_dest_path: /home/runner/.ssh/id_rsa_azure_demo
     ask_variables_on_launch: true
     credentials:
-      - "{{ azure_credential.name }}"
+      - "{{ credentials.azure_service_principal.name }}"
   when:
-    - seed_content_lab
+    - seed_lab_content
     - azure_credential is defined
+    - credentials.azure_service_principal.name is defined
     - content_lab_project_azure is defined
   register: create_network_peering_demo_template
   tags:
     - templates
 
-- name: Azure - Delete Network Peering Demo
+- name: Content Lab - Azure - Delete Network Peering Demo
   ansible.controller.job_template:
-    name: Azure - Delete Network Peering Demo
+    name: Content Lab - Azure - Delete Network Peering Demo
     project: "{{ content_lab_project_azure.name }}"
     playbook: playbook_delete_transit_network.yml
     inventory: localhost
@@ -213,39 +221,41 @@
       region: "{{ azure_region }}"
     ask_variables_on_launch: true
     credentials:
-      - "{{ azure_credential.name }}"
+      - "{{ credentials.azure_service_principal.name }}"
   when:
-    - seed_content_lab
+    - seed_lab_content
     - azure_credential is defined
+    - credentials.azure_service_principal.name is defined
     - content_lab_project_azure is defined
   register: delete_network_peering_demo_template
   tags:
     - templates
 
-- name: Azure - Run DNF Update
+- name: Content Lab - Azure - Run DNF Update
   ansible.controller.job_template:
-    name: Azure - Run DNF Update
+    name: Content Lab - Azure - Run DNF Update
     job_type: run
     project: "{{ content_lab_project_azure.name }}"
     playbook: playbook_update_rhel_vms.yml
     inventory: "{{ azure_inventory.name }}"
     limit: rhel
     credentials:
-      - "{{ azure_vm_credential.name }}"
+      - "{{ credentials.ssh.name }}"
     become_enabled: true
     job_slice_count: 5
     state: present
   when:
-    - seed_content_lab
-    - azure_vm_credential is defined
+    - seed_lab_content
+    - vm_credential is defined
+    - credentials.ssh.name is defined
     - content_lab_project_azure is defined
   register: rhel_vm_update_template
   tags:
     - templates
 
-- name: Azure - Install Arc Agent
+- name: Content Lab - Azure - Install Arc Agent
   ansible.controller.job_template:
-    name: Azure - Install Arc Agent
+    name: Content Lab - Azure - Install Arc Agent
     inventory: "{{ azure_inventory.name }}"
     playbook: playbook_install_arc_agent.yml
     project: "{{ content_lab_project_azure.name }}"
@@ -257,24 +267,26 @@
       service_principal_id: "{% raw %}{{ lookup('env', 'AZURE_CLIENT_ID') }}{% endraw %}"
       service_principal_secret: "{% raw %}{{ lookup('env', 'AZURE_SECRET') }}{% endraw %}"
     credentials:
-      - "{{ azure_vm_credential.name }}"
-      - "{{ azure_credential.name }}"
+      - "{{ credentials.ssh.name }}"
+      - "{{ credentials.azure_service_principal.name }}"
     limit: rhel
     become_enabled: true
     ask_inventory_on_launch: true
     ask_limit_on_launch: true
   when:
-    - seed_content_lab
+    - seed_lab_content
     - azure_credential is defined
-    - azure_vm_credential is defined
+    - credentials.azure_service_principal.name is defined
+    - vm_credential is defined
+    - credentials.ssh.name is defined
     - content_lab_project_azure is defined
   register: install_arc_agent_template
   tags:
     - templates
 
-- name: Azure - Enable Arc Extensions
+- name: Content Lab - Azure - Enable Arc Extensions
   ansible.controller.job_template:
-    name: Azure - Enable Arc Extensions
+    name: Content Lab - Azure - Enable Arc Extensions
     inventory: "{{ azure_inventory.name }}"
     playbook: playbook_enable_arc_extension.yml
     project: "{{ content_lab_project_azure.name }}"
@@ -284,19 +296,20 @@
       arc_hosts: "{% raw %}{{ hostvars.values() | selectattr('group_names','contains', 'arc') | map(attribute='inventory_hostname') | list }}{% endraw %}"
       extension: azure_monitor_agent # this name is from the extension variable mapping in the content lab collection
     credentials:
-      - "{{ azure_credential.name }}"
+      - "{{ credentials.azure_service_principal.name }}"
     ask_variables_on_launch: true
   when:
-    - seed_content_lab
+    - seed_lab_content
     - azure_credential is defined
+    - credentials.azure_service_principal.name is defined
     - content_lab_project_azure is defined
   register: enable_arc_extensions_template
   tags:
     - templates
 
-- name: Azure - Disable Arc Extensions
+- name: Content Lab - Azure - Disable Arc Extensions
   ansible.controller.job_template:
-    name: Azure - Disable Arc Extensions
+    name: Content Lab - Azure - Disable Arc Extensions
     inventory: "{{ azure_inventory.name }}"
     playbook: playbook_disable_arc_extension.yml
     project: "{{ content_lab_project_azure.name }}"
@@ -306,19 +319,20 @@
       arc_hosts: "{% raw %}{{ hostvars.values() | selectattr('group_names','contains', 'arc') | map(attribute='inventory_hostname') | list }}{% endraw %}"
       extension: azure_monitor_agent # this name is from the extension variable mapping in the content lab collection
     credentials:
-      - "{{ azure_credential.name }}"
+      - "{{ credentials.azure_service_principal.name }}"
     ask_variables_on_launch: true
   when:
-    - seed_content_lab
+    - seed_lab_content
     - azure_credential is defined
+    - credentials.azure_service_principal.name is defined
     - content_lab_project_azure is defined
   register: disable_arc_extensions_template
   tags:
     - templates
 
-- name: Azure - Replace Log Analytics with Azure Monitor
+- name: Content Lab - Azure - Replace Log Analytics with Azure Monitor
   ansible.controller.job_template:
-    name: Azure - Replace Log Analytics with Azure Monitor
+    name: Content Lab - Azure - Replace Log Analytics with Azure Monitor
     inventory: "{{ azure_inventory.name }}"
     playbook: playbook_replace_log_analytics_with_arc_linux.yml
     project: "{{ content_lab_project_azure.name }}"
@@ -327,43 +341,45 @@
       resource_group: "{{ azure_resource_group }}"
       linux_hosts: "{% raw %}{{ hostvars.values() | selectattr('group_names','contains', 'arc') | map(attribute='inventory_hostname') | list }}{% endraw %}"
     credentials:
-      - "{{ azure_credential.name }}"
+      - "{{ credentials.azure_service_principal.name }}"
   when:
-    - seed_content_lab
+    - seed_lab_content
     - azure_credential is defined
+    - credentials.azure_service_principal.name is defined
     - content_lab_project_azure is defined
   register: replace_log_analytics_with_azure_monitor_template
   tags:
     - templates
 
-- name: Azure - Create Log Analytics Workspace
+- name: Content Lab - Azure - Create Log Analytics Workspace
   ansible.controller.job_template:
     name: Azure - Create Log Analytics Workspace
     inventory: localhost
     playbook: playbook_create_log_analytics_workspace.yml
     project: "{{ content_lab_project_azure.name }}"
     credentials:
-      - "{{ azure_vm_credential.name }}"
+      - "{{ credentials.ssh.name }}"
     extra_vars:
       resource_group: "{{ azure_resource_group }}"
       workspace_name: "{{ job_templates.log_analytics.ws_name }}"
     limit: rhel
   when:
-    - seed_content_lab
-    - azure_vm_credential is defined
+    - seed_lab_content
+    - vm_credential is defined
+    - credentials.ssh.name is defined
     - content_lab_project_azure is defined
   register: create_log_analytics_workspace_template
   tags:
     - templates
 
-- name: Azure - Install Log Analytics Agent
+- name: Content Lab - Azure - Install Log Analytics Agent
   ansible.controller.job_template:
     name: Azure - Install Log Analytics Agent
     inventory: "{{ azure_inventory.name }}"
     playbook: playbook_install_log_analytics_agent.yml
     project: "{{ content_lab_project_azure.name }}"
     credentials:
-      - "{{ azure_vm_credential.name }}"
+      - "{{ credentials.ssh.name }}"
     extra_vars:
       resource_group: "{{ azure_resource_group }}"
       workspace_name: "{{ job_templates.log_analytics.ws_name }}"
@@ -372,61 +388,66 @@
     ask_inventory_on_launch: true
     ask_limit_on_launch: true
   when:
-    - seed_content_lab
-    - azure_vm_credential is defined
+    - seed_lab_content
+    - vm_credential is defined
+    - credentials.ssh.name is defined
     - content_lab_project_azure is defined
   register: install_log_analytics_agent_template
   tags:
     - templates
 
-- name: Azure - Uninstall Log Analytics Agent
+- name: Content Lab - Azure - Uninstall Log Analytics Agent
   ansible.controller.job_template:
-    name: Azure - Uninstall Log Analytics Agent
+    name: Content Lab - Azure - Uninstall Log Analytics Agent
     inventory: "{{ azure_inventory.name }}"
     playbook: playbook_uninstall_log_analytics_agent.yml
     project: "{{ content_lab_project_azure.name }}"
     credentials:
-      - "{{ azure_vm_credential.name }}"
+      - "{{ credentials.ssh.name }}"
     become_enabled: true
     ask_inventory_on_launch: true
     ask_limit_on_launch: true
   when:
-    - seed_content_lab
-    - azure_vm_credential is defined
+    - seed_lab_content
+    - vm_credential is defined
+    - credentials.ssh.name is defined
     - content_lab_project_azure is defined
   register: uninstall_log_analytics_agent_template
   tags:
     - templates
 
-- name: Run Ephemeral Workload Test
+- name: Content Lab - Run Ephemeral Workload Test
   ansible.controller.job_template:
-    name: Azure Demos - Ephemeral Workload Test
+    name: Content Lab - Azure Demos - Ephemeral Workload Test
     job_type: run
     project: "{{ content_lab_project_demo.name }}"
     playbook: project/emphemeral_workload_test.yml
     inventory: localhost
     credentials:
-      - "{{ controller_credential.name }}"
-      - "{{ azure_credential.name }}"
-      - "{{ azure_vm_credential.name }}"
+      - "{{ credentials.azure_service_principal.name }}"
+      - "{{ credentials.controller.name }}"
+      - "{{ credentials.ssh.name }}"
     become_enabled: true
     job_slice_count: 1
     state: present
   when:
-    - seed_content_lab
+    - seed_lab_content
     - azure_credential is defined
-    - azure_vm_credential is defined
+    - credentials.azure_service_principal.name is defined
+    - vm_credential is defined
+    - credentials.ssh.name is defined
     - controller_credential is defined
+    - credentials.controller.name is defined
     - content_lab_project_demo is defined
   register: ephemeral_workload_template
   tags:
     - templates
 
-- name: Azure web application deployment demo
+- name: Validated Content - Azure web application deployment demo
   ansible.controller.job_template:
-    name: Azure web application deployment demo
+    name: Validated Content - Azure web application deployment demo
     job_type: run
-    execution_environment: "{{ cloud_services_ee.name }}"
+    execution_environment: "{{ execution_environments.cloud_services_ee_name }}"
     project: "{{ seeded_content_project_azure.name }}"
     playbook: playbooks/webapp.yml
     ask_credential_on_launch: true
@@ -440,16 +461,17 @@
   when:
     - seed_validated_content
     - cloud_services_ee is defined
+    - execution_environments.cloud_services_ee_name is defined
     - seeded_content_project_azure is defined
   register: ephemeral_workload_template
   tags:
     - templates
 
-- name: Azure web application migration demo
+- name: Validated Content - Azure web application migration demo
   ansible.controller.job_template:
-    name: Azure web application migration demo
+    name: Validated Content - Azure web application migration demo
     job_type: run
-    execution_environment: "{{ cloud_services_ee.name }}"
+    execution_environment: "{{ execution_environments.cloud_services_ee_name }}"
     project: "{{ seeded_content_project_azure.name }}"
     playbook: playbooks/vmss_migrate.yml
     ask_credential_on_launch: true
@@ -464,6 +486,7 @@
   when:
     - seed_validated_content
     - cloud_services_ee is defined
+    - execution_environments.cloud_services_ee_name is defined
     - seeded_content_project_azure is defined
   register: ephemeral_workload_template
   tags:

--- a/roles/controller/tasks/job_templates.yml
+++ b/roles/controller/tasks/job_templates.yml
@@ -81,6 +81,7 @@
     - seed_content_lab
     - azure_credential is defined
     - content_lab_project_azure is defined
+  register: create_rhel_vm_template
   tags:
     - templates
 
@@ -102,6 +103,7 @@
     - seed_content_lab
     - azure_credential is defined
     - content_lab_project_azure is defined
+  register: delete_rhel_vm_template
   tags:
     - templates
 
@@ -131,6 +133,7 @@
     - seed_content_lab
     - azure_credential is defined
     - content_lab_project_azure is defined
+  register: create_windows_vm_template
   tags:
     - templates
 
@@ -152,12 +155,13 @@
     - seed_content_lab
     - azure_credential is defined
     - content_lab_project_azure is defined
+  register: delete_windows_vm_template
   tags:
     - templates
 
-- name: Azure - Destroy Resource Group
+- name: Azure - Delete Resource Group
   ansible.controller.job_template:
-    name: Azure - Destroy Resource Group
+    name: Azure - Delete Resource Group
     inventory: localhost
     playbook: playbook_delete_resource_group.yml
     project: "{{ content_lab_project_azure.name }}"
@@ -170,6 +174,7 @@
     - seed_content_lab
     - azure_credential is defined
     - content_lab_project_azure is defined
+  register: delete_resource_group_template
   tags:
     - templates
 
@@ -193,12 +198,13 @@
     - seed_content_lab
     - azure_credential is defined
     - content_lab_project_azure is defined
+  register: create_network_peering_demo_template
   tags:
     - templates
 
-- name: Azure - Destroy Network Peering Demo
+- name: Azure - Delete Network Peering Demo
   ansible.controller.job_template:
-    name: Azure - Destroy Network Peering Demo
+    name: Azure - Delete Network Peering Demo
     project: "{{ content_lab_project_azure.name }}"
     playbook: playbook_delete_transit_network.yml
     inventory: localhost
@@ -212,6 +218,7 @@
     - seed_content_lab
     - azure_credential is defined
     - content_lab_project_azure is defined
+  register: delete_network_peering_demo_template
   tags:
     - templates
 
@@ -232,6 +239,7 @@
     - seed_content_lab
     - azure_vm_credential is defined
     - content_lab_project_azure is defined
+  register: rhel_vm_update_template
   tags:
     - templates
 
@@ -260,6 +268,7 @@
     - azure_credential is defined
     - azure_vm_credential is defined
     - content_lab_project_azure is defined
+  register: install_arc_agent_template
   tags:
     - templates
 
@@ -281,6 +290,7 @@
     - seed_content_lab
     - azure_credential is defined
     - content_lab_project_azure is defined
+  register: enable_arc_extensions_template
   tags:
     - templates
 
@@ -302,6 +312,7 @@
     - seed_content_lab
     - azure_credential is defined
     - content_lab_project_azure is defined
+  register: disable_arc_extensions_template
   tags:
     - templates
 
@@ -321,6 +332,7 @@
     - seed_content_lab
     - azure_credential is defined
     - content_lab_project_azure is defined
+  register: replace_log_analytics_with_azure_monitor_template
   tags:
     - templates
 
@@ -340,6 +352,7 @@
     - seed_content_lab
     - azure_vm_credential is defined
     - content_lab_project_azure is defined
+  register: create_log_analytics_workspace_template
   tags:
     - templates
 
@@ -362,6 +375,7 @@
     - seed_content_lab
     - azure_vm_credential is defined
     - content_lab_project_azure is defined
+  register: install_log_analytics_agent_template
   tags:
     - templates
 
@@ -380,6 +394,7 @@
     - seed_content_lab
     - azure_vm_credential is defined
     - content_lab_project_azure is defined
+  register: uninstall_log_analytics_agent_template
   tags:
     - templates
 
@@ -403,5 +418,6 @@
     - azure_vm_credential is defined
     - controller_credential is defined
     - content_lab_project_demo is defined
+  register: ephemeral_workload_template
   tags:
     - templates

--- a/roles/controller/tasks/projects.yml
+++ b/roles/controller/tasks/projects.yml
@@ -3,42 +3,73 @@
   ansible.controller.project:
     name: Demo Project
     state: absent
-  when: (delete_demo_project is defined) and (delete_demo_project | bool)
+  when:
+    - delete_demo_project is defined
+    - (delete_demo_project | bool)
   tags:
     - projects
+    - azure
 
 - name: Add Azure Demo Project
   ansible.controller.project:
     name: Ansible - Azure Demo
     description: Azure Demo
-    default_environment: Harwell - Cloud EE
+    default_environment: Cloud EE
     organization: "{{ awx_organization }}"  # Organization is required in projects
     scm_type: git
-    scm_url: "{{ projects.azure_demo_project_url }}"
+    scm.url: "{{ projects.azure_demo_project.url }}"
     state: present
+  when:
+    - seed_content_lab
+  register: content_lab_project_demo
   tags:
     - projects
+    - azure
 
 - name: Add Ansible Cloud Content Lab Azure Project
   ansible.controller.project:
     name: Ansible Cloud Content Lab - Azure Roles
     description: Ansible Cloud Content Lab - Azure Roles
-    default_environment: Harwell - Cloud EE
+    default_environment: Cloud EE
     organization: "{{ awx_organization }}"  # Organization is required in projects
     scm_type: git
-    scm_url: "{{ projects.azure_lab_roles_url }}"
+    scm.url: "{{ projects.azure_lab_roles.url }}"
     state: present
+  when:
+    - seed_content_lab
+  register: content_lab_project_azure
   tags:
     - projects
+    - azure
 
 - name: Add Ansible Cloud Content Lab AWS Project
   ansible.controller.project:
     name: Ansible Cloud Content Lab - AWS Roles
-    description: Ansible Cloud Content Lab - Azure Roles
-    default_environment: Harwell - Cloud EE
+    description: Ansible Cloud Content Lab - AWS Roles
+    default_environment: Cloud EE
     organization: "{{ awx_organization }}"  # Organization is required in projects
     scm_type: git
-    scm_url: "{{ projects.aws_lab_roles_url }}"
+    scm.url: "{{ projects.aws_lab_roles.url }}"
     state: present
+  when:
+    - seed_content_lab
+  register: content_lab_project_aws
   tags:
     - projects
+    - aws
+
+- name: Add Ansible Cloud Seeded Content Project
+  ansible.controller.project:
+    name: cloud.azure_ops
+    description: Ansible Automation Platform Cloud Seeded Content - Azure
+    default_environment: Cloud EE
+    organization: "{{ awx_organization }}"  # Organization is required in projects
+    scm_type: git
+    scm_url: "{{ projects.azure_seeded_content_url }}"
+    state: present
+  when:
+    - seed_validated_content
+  register: seeded_content_project_azure
+  tags:
+    - projects
+    - azure

--- a/roles/controller/tasks/projects.yml
+++ b/roles/controller/tasks/projects.yml
@@ -14,7 +14,7 @@
   ansible.controller.project:
     name: "{{ projects.azure_demo_project.name }}"
     description: Azure Demo
-    default_environment: "{{ execution_environments.cloud_ee_name }}"
+    default_environment: "{{ execution_environments.cloud_ee.name }}"
     organization: "{{ awx_organization }}"  # Organization is required in projects
     scm_type: git
     scm_url: "{{ projects.azure_demo_project.url }}"
@@ -32,7 +32,7 @@
   ansible.controller.project:
     name: "{{ projects.azure_lab_roles.name }}"
     description: Ansible Cloud Content Lab - Azure Roles
-    default_environment: "{{ execution_environments.cloud_ee_name }}"
+    default_environment: "{{ execution_environments.cloud_ee.name }}"
     organization: "{{ awx_organization }}"  # Organization is required in projects
     scm_type: git
     scm_url: "{{ projects.azure_lab_roles.url }}"
@@ -50,7 +50,7 @@
   ansible.controller.project:
     name: "{{ projects.aws_lab_roles.name }}"
     description: Ansible Cloud Content Lab - AWS Roles
-    default_environment: "{{ execution_environments.cloud_ee_name }}"
+    default_environment: "{{ execution_environments.cloud_ee.name }}"
     organization: "{{ awx_organization }}"  # Organization is required in projects
     scm_type: git
     scm_url: "{{ projects.aws_lab_roles.url }}"
@@ -68,7 +68,7 @@
   ansible.controller.project:
     name: "{{ projects.azure_seeded_content.name }}"
     description: Ansible Automation Platform Cloud Seeded Content - Azure
-    default_environment: "{{ execution_environments.cloud_services_ee_name }}"
+    default_environment: "{{ execution_environments.cloud_services.name }}"
     organization: "{{ awx_organization }}"  # Organization is required in projects
     scm_type: git
     scm_url: "{{ projects.azure_seeded_content.url }}"

--- a/roles/controller/tasks/projects.yml
+++ b/roles/controller/tasks/projects.yml
@@ -10,9 +10,9 @@
     - projects
     - azure
 
-- name: Add Azure Demo Project
+- name: Add Ansible Cloud Content Lab Azure Demo Project
   ansible.controller.project:
-    name: Ansible - Azure Demo
+    name: Ansible Cloud Content Lab - Azure Demo
     description: Azure Demo
     default_environment: Cloud EE
     organization: "{{ awx_organization }}"  # Organization is required in projects
@@ -60,15 +60,16 @@
 
 - name: Add Ansible Cloud Seeded Content Project
   ansible.controller.project:
-    name: cloud.azure_ops
+    name: Ansible Validated Content - Azure Demos
     description: Ansible Automation Platform Cloud Seeded Content - Azure
-    default_environment: Cloud EE
+    default_environment: "{{ cloud_services_ee.name }}"
     organization: "{{ awx_organization }}"  # Organization is required in projects
     scm_type: git
-    scm_url: "{{ projects.azure_seeded_content_url }}"
+    scm_url: "{{ projects.azure_seeded_content.url }}"
     state: present
   when:
     - seed_validated_content
+    - cloud_services_ee is present
   register: seeded_content_project_azure
   tags:
     - projects

--- a/roles/controller/tasks/projects.yml
+++ b/roles/controller/tasks/projects.yml
@@ -14,13 +14,13 @@
   ansible.controller.project:
     name: Ansible Cloud Content Lab - Azure Demo
     description: Azure Demo
-    default_environment: Cloud EE
+    default_environment: "{{ execution_environments.cloud_ee_name }}"
     organization: "{{ awx_organization }}"  # Organization is required in projects
     scm_type: git
-    scm.url: "{{ projects.azure_demo_project.url }}"
+    scm_url: "{{ projects.azure_demo_project.url }}"
     state: present
   when:
-    - seed_content_lab
+    - seed_lab_content
   register: content_lab_project_demo
   tags:
     - projects
@@ -30,13 +30,13 @@
   ansible.controller.project:
     name: Ansible Cloud Content Lab - Azure Roles
     description: Ansible Cloud Content Lab - Azure Roles
-    default_environment: Cloud EE
+    default_environment: "{{ execution_environments.cloud_ee_name }}"
     organization: "{{ awx_organization }}"  # Organization is required in projects
     scm_type: git
-    scm.url: "{{ projects.azure_lab_roles.url }}"
+    scm_url: "{{ projects.azure_lab_roles.url }}"
     state: present
   when:
-    - seed_content_lab
+    - seed_lab_content
   register: content_lab_project_azure
   tags:
     - projects
@@ -46,13 +46,13 @@
   ansible.controller.project:
     name: Ansible Cloud Content Lab - AWS Roles
     description: Ansible Cloud Content Lab - AWS Roles
-    default_environment: Cloud EE
+    default_environment: "{{ execution_environments.cloud_ee_name }}"
     organization: "{{ awx_organization }}"  # Organization is required in projects
     scm_type: git
-    scm.url: "{{ projects.aws_lab_roles.url }}"
+    scm_url: "{{ projects.aws_lab_roles.url }}"
     state: present
   when:
-    - seed_content_lab
+    - seed_lab_content
   register: content_lab_project_aws
   tags:
     - projects
@@ -62,14 +62,13 @@
   ansible.controller.project:
     name: Ansible Validated Content - Azure Demos
     description: Ansible Automation Platform Cloud Seeded Content - Azure
-    default_environment: "{{ cloud_services_ee.name }}"
+    default_environment: "{{ execution_environments.cloud_services_ee_name }}"
     organization: "{{ awx_organization }}"  # Organization is required in projects
     scm_type: git
     scm_url: "{{ projects.azure_seeded_content.url }}"
     state: present
   when:
     - seed_validated_content
-    - cloud_services_ee is present
   register: seeded_content_project_azure
   tags:
     - projects

--- a/roles/controller/tasks/projects.yml
+++ b/roles/controller/tasks/projects.yml
@@ -4,6 +4,7 @@
     name: Demo Project
     state: absent
   when:
+    - (seed_lab_content | bool)
     - delete_demo_project is defined
     - (delete_demo_project | bool)
   tags:
@@ -22,7 +23,7 @@
     update_project: true
     wait: true
   when:
-    - seed_lab_content
+    - (seed_lab_content | bool)
   register: content_lab_project_demo
   tags:
     - projects
@@ -40,7 +41,7 @@
     update_project: true
     wait: true
   when:
-    - seed_lab_content
+    - (seed_lab_content | bool)
   register: content_lab_project_azure
   tags:
     - projects
@@ -58,7 +59,7 @@
     update_project: true
     wait: true
   when:
-    - seed_lab_content
+    - (seed_lab_content | bool)
   register: content_lab_project_aws
   tags:
     - projects
@@ -76,7 +77,7 @@
     update_project: true
     wait: true
   when:
-    - seed_validated_content
+    - (seed_validated_content | bool)
   register: seeded_content_project_azure
   tags:
     - projects

--- a/roles/controller/tasks/projects.yml
+++ b/roles/controller/tasks/projects.yml
@@ -12,13 +12,15 @@
 
 - name: Add Ansible Cloud Content Lab Azure Demo Project
   ansible.controller.project:
-    name: Ansible Cloud Content Lab - Azure Demo
+    name: "{{ projects.azure_demo_project.name }}"
     description: Azure Demo
     default_environment: "{{ execution_environments.cloud_ee_name }}"
     organization: "{{ awx_organization }}"  # Organization is required in projects
     scm_type: git
     scm_url: "{{ projects.azure_demo_project.url }}"
     state: present
+    update_project: true
+    wait: true
   when:
     - seed_lab_content
   register: content_lab_project_demo
@@ -28,13 +30,15 @@
 
 - name: Add Ansible Cloud Content Lab Azure Project
   ansible.controller.project:
-    name: Ansible Cloud Content Lab - Azure Roles
+    name: "{{ projects.azure_lab_roles.name }}"
     description: Ansible Cloud Content Lab - Azure Roles
     default_environment: "{{ execution_environments.cloud_ee_name }}"
     organization: "{{ awx_organization }}"  # Organization is required in projects
     scm_type: git
     scm_url: "{{ projects.azure_lab_roles.url }}"
     state: present
+    update_project: true
+    wait: true
   when:
     - seed_lab_content
   register: content_lab_project_azure
@@ -44,13 +48,15 @@
 
 - name: Add Ansible Cloud Content Lab AWS Project
   ansible.controller.project:
-    name: Ansible Cloud Content Lab - AWS Roles
+    name: "{{ projects.aws_lab_roles.name }}"
     description: Ansible Cloud Content Lab - AWS Roles
     default_environment: "{{ execution_environments.cloud_ee_name }}"
     organization: "{{ awx_organization }}"  # Organization is required in projects
     scm_type: git
     scm_url: "{{ projects.aws_lab_roles.url }}"
     state: present
+    update_project: true
+    wait: true
   when:
     - seed_lab_content
   register: content_lab_project_aws
@@ -60,13 +66,15 @@
 
 - name: Add Ansible Cloud Seeded Content Project
   ansible.controller.project:
-    name: Ansible Validated Content - Azure Demos
+    name: "{{ projects.azure_seeded_content.name }}"
     description: Ansible Automation Platform Cloud Seeded Content - Azure
     default_environment: "{{ execution_environments.cloud_services_ee_name }}"
     organization: "{{ awx_organization }}"  # Organization is required in projects
     scm_type: git
     scm_url: "{{ projects.azure_seeded_content.url }}"
     state: present
+    update_project: true
+    wait: true
   when:
     - seed_validated_content
   register: seeded_content_project_azure

--- a/roles/controller/tasks/schedules.yml
+++ b/roles/controller/tasks/schedules.yml
@@ -7,7 +7,7 @@
     rrule: "{{ query('ansible.controller.schedule_rrule', 'hour', start_date='2022-01-01 23:30:00', timezone='US/Eastern') }}"
   register: result
   when:
-    - seed_lab_content
+    - (seed_lab_content | bool)
     - schedules.ephemeral_workload.name is defined
     - workflows.ephemeral_workload.name is defined
   tags:

--- a/roles/controller/tasks/schedules.yml
+++ b/roles/controller/tasks/schedules.yml
@@ -3,7 +3,7 @@
   ansible.controller.schedule:
     name: RHEL Ephemeral VM Workflow
     state: present
-    unified_job_template: ansible_on_clouds.setup_and_config.ephemeral_vm_workload
+    unified_job_template: Ephemeral VM Workflow
     rrule: "{{ query('ansible.controller.schedule_rrule', 'hour', start_date='2022-01-01 23:30:00', timezone='US/Eastern') }}"
   register: result
   tags:

--- a/roles/controller/tasks/schedules.yml
+++ b/roles/controller/tasks/schedules.yml
@@ -1,10 +1,14 @@
 ---
 - name: Schedule RHEL Demo Workflow Every Hour
   ansible.controller.schedule:
-    name: RHEL Ephemeral VM Workflow
+    name: "{{ schedules.ephemeral_workload.name }}"
     state: present
-    unified_job_template: Ephemeral VM Workflow
+    unified_job_template: "{{ workflows.ephemeral_workload.name }}"
     rrule: "{{ query('ansible.controller.schedule_rrule', 'hour', start_date='2022-01-01 23:30:00', timezone='US/Eastern') }}"
   register: result
+  when:
+    - seed_lab_content
+    - schedules.ephemeral_workload.name is defined
+    - workflows.ephemeral_workload.name is defined
   tags:
     - schedules

--- a/roles/controller/tasks/settings.yml
+++ b/roles/controller/tasks/settings.yml
@@ -10,7 +10,9 @@
   ansible.controller.settings:
     settings:
       SESSION_COOKIE_AGE: "{{ session_cookie_age }}"
-  when: session_cookie_age is defined and ((session_cookie_age | int) > 0)
+  when: 
+    - session_cookie_age is defined
+    - (session_cookie_age | int) > 0
   tags:
     - settings
 
@@ -18,7 +20,8 @@
   ansible.controller.settings:
     settings:
       DEFAULT_EXECUTION_ENVIRONMENT: "{{ default_execution_environment }}"
-  when: default_execution_environment is defined
+  when:
+    - default_execution_environment is defined
   tags:
     - settings
 
@@ -26,7 +29,8 @@
   ansible.controller.settings:
     settings:
       SOCIAL_AUTH_AZUREAD_OAUTH2_KEY: "{{ lookup('env', 'SOCIAL_AUTH_AZUREAD_OAUTH2_KEY') }}"
-  when: lookup('env', 'SOCIAL_AUTH_AZUREAD_OAUTH2_KEY') | length > 0
+  when:
+    - lookup('env', 'SOCIAL_AUTH_AZUREAD_OAUTH2_KEY') | length > 0
   tags:
     - settings
 
@@ -34,6 +38,7 @@
   ansible.controller.settings:
     settings:
       SOCIAL_AUTH_AZUREAD_OAUTH2_SECRET: "{{ lookup('env', 'SOCIAL_AUTH_AZUREAD_OAUTH2_SECRET') }}"
-  when: lookup('env', 'SOCIAL_AUTH_AZUREAD_OAUTH2_SECRET') | length > 0
+  when:
+    - lookup('env', 'SOCIAL_AUTH_AZUREAD_OAUTH2_SECRET') | length > 0
   tags:
     - settings

--- a/roles/controller/tasks/workflows.yml
+++ b/roles/controller/tasks/workflows.yml
@@ -1,12 +1,12 @@
 ---
 - name: Create a workflow to create a RHEL VM, run an automation against the VM, and then destroy the VM
   ansible.controller.workflow_job_template:
-    name: ansible_on_clouds.setup_and_config.ephemeral_vm_workload
+    name: Linux - Ephemeral VM Workflow
     inventory: localhost
     workflow_nodes:
       - identifier: Create VM
         unified_job_template:
-          name: lab.azure_roles.create_rhel_vm
+          name: "{{ create_rhel_vm_template.name }}"
           type: job_template
         related:
           success_nodes:
@@ -16,7 +16,7 @@
 
       - identifier: Run DNF Update
         unified_job_template:
-          name: lab.azure_roles.update_rhel_vms
+          name: "{{ rhel_vm_update_template.name }}"
           type: job_template
         related:
           always_nodes:
@@ -25,19 +25,24 @@
       - identifier: Delete VM
         all_parents_must_converge: false
         unified_job_template:
-          name: lab.azure_roles.delete_rhel_vm
+          name: "{{ delete_rhel_vm_template }}"
           type: job_template
+  when:
+    - seed_content_lab
+    - create_rhel_vm_template is defined
+    - rhel_vm_update_template is defined
+    - delete_rhel_vm_template is defined
   tags:
     - workflows
 
 - name: Azure - Install log analytics
   ansible.controller.workflow_job_template:
-    name: lab.azure_roles.install_log_analytics_workflow
+    name: Azure - Install Log Analytics Workflow
     description: Create a lot analytics workspace and install the log analytics agent on attached VMs.
     workflow_nodes:
       - identifier: Create Log Analytics Workspace
         unified_job_template:
-          name: lab.azure_roles.create_log_analytics_workspace
+          name: "{{ create_log_analytics_workspace_template.name }}"
           type: job_template
           inventory: localhost
         related:
@@ -46,9 +51,13 @@
 
       - identifier: Install Log Analytics Agent
         unified_job_template:
-          name: lab.azure_roles.log_analytics_install_agent
+          name: "{{ install_log_analytics_agent_template.name }}"
           type: job_template
           inventory: Azure
+  when:
+    - seed_content_lab
+    - create_log_analytics_workspace_template is defined
+    - install_log_analytics_agent_template is defined
   tags:
     - workflows
 
@@ -77,7 +86,7 @@
     workflow_nodes:
       - identifier: Install Arc Agent
         unified_job_template:
-          name: lab.azure_roles.arc_install_agent
+          name: "{{ install_arc_agent_template.name }}"
           type: job_template
           inventory: Azure
         related:
@@ -86,7 +95,7 @@
 
       - identifier: Replace Log Analytics with Azure Monitor
         unified_job_template:
-          name: lab.azure_roles.arc_replace_log_analytics_with_azure_monitor
+          name: "{{ replace_log_analytics_with_azure_monitor_template.name }}"
           type: job_template
           inventory: localhost
         related:
@@ -96,8 +105,13 @@
       - identifier: Uninstall Log Analytics Agent
         all_parents_must_converge: false
         unified_job_template:
-          name: lab.azure_roles.log_analytics_uninstall_agent
+          name: "{{ uninstall_log_analytics_agent_template.name }}"
           type: job_template
           inventory: Azure
+  when:
+    - seed_content_lab
+    - install_arc_agent_template is defined
+    - replace_log_analytics_with_azure_monitor_template is defined
+    - uninstall_log_analytics_agent_template is defined
   tags:
     - workflows

--- a/roles/controller/tasks/workflows.yml
+++ b/roles/controller/tasks/workflows.yml
@@ -1,12 +1,12 @@
 ---
 - name: Create a workflow to create a RHEL VM, run an automation against the VM, and then destroy the VM
   ansible.controller.workflow_job_template:
-    name: Linux - Ephemeral VM Workflow
-    inventory: localhost
+    name: Content Lab - Linux - Ephemeral VM Workflow
+    inventory: "{{ inventories.localhost.name }}"
     workflow_nodes:
       - identifier: Create VM
         unified_job_template:
-          name: "{{ create_rhel_vm_template.name }}"
+          name: "{{ job_templates.create_rhel_vm.name }}"
           type: job_template
         related:
           success_nodes:
@@ -16,7 +16,7 @@
 
       - identifier: Run DNF Update
         unified_job_template:
-          name: "{{ rhel_vm_update_template.name }}"
+          name: "{{ job_templates.dnf_update.name }}"
           type: job_template
         related:
           always_nodes:
@@ -25,45 +25,49 @@
       - identifier: Delete VM
         all_parents_must_converge: false
         unified_job_template:
-          name: "{{ delete_rhel_vm_template }}"
+          name: "{{ job_templates.delete_rhel_vm.name }}"
           type: job_template
   when:
     - seed_lab_content
-    - create_rhel_vm_template is defined
-    - rhel_vm_update_template is defined
-    - delete_rhel_vm_template is defined
+    - job_templates.create_rhel_vm.name is defined
+    - job_templates.dnf_update.name is defined
+    - job_templates.delete_rhel_vm.name is defined
+    - localhost_inventory is defined
+    - inventories.localhost.name is defined
   tags:
     - workflows
 
 - name: Azure - Install log analytics
   ansible.controller.workflow_job_template:
-    name: Azure - Install Log Analytics Workflow
+    name: Content Lab - Azure - Install Log Analytics Workflow
     description: Create a lot analytics workspace and install the log analytics agent on attached VMs.
     workflow_nodes:
       - identifier: Create Log Analytics Workspace
         unified_job_template:
-          name: "{{ create_log_analytics_workspace_template.name }}"
+          name: "{{ job_templates.create_log_analytics_ws.name }}"
           type: job_template
-          inventory: localhost
+          inventory: "{{ inventories.localhost.name }}"
         related:
           success_nodes:
             - identifier: Install Log Analytics Agent
 
       - identifier: Install Log Analytics Agent
         unified_job_template:
-          name: "{{ install_log_analytics_agent_template.name }}"
+          name: "{{ job_templates.install_log_analytics.name }}"
           type: job_template
           inventory: Azure
   when:
     - seed_lab_content
-    - create_log_analytics_workspace_template is defined
-    - install_log_analytics_agent_template is defined
+    - job_templates.create_log_analytics_ws.name is defined
+    - job_templates.install_log_analytics.name is defined
+    - localhost_inventory is defined
+    - inventories.localhost.name is defined
   tags:
     - workflows
 
 - name: Azure Arc - Replace Log Analytics with Azure Monitor
   ansible.controller.workflow_job_template:
-    name: lab.azure_roles.arc_log_migration
+    name: Content Lab - Azure - Arc Log Migration
     description: Migrate hosts from Azure Log Analytics Agent to Azure Monitor Agent with Azure Arc
     survey_enabled: true
     survey_spec:
@@ -86,7 +90,7 @@
     workflow_nodes:
       - identifier: Install Arc Agent
         unified_job_template:
-          name: "{{ install_arc_agent_template.name }}"
+          name: "{{ job_templates.install_arc_agent.name }}"
           type: job_template
           inventory: Azure
         related:
@@ -95,7 +99,7 @@
 
       - identifier: Replace Log Analytics with Azure Monitor
         unified_job_template:
-          name: "{{ replace_log_analytics_with_azure_monitor_template.name }}"
+          name: "{{ job_templates.replace_log_analytics_with_azure_monitor.name }}"
           type: job_template
           inventory: localhost
         related:
@@ -105,13 +109,13 @@
       - identifier: Uninstall Log Analytics Agent
         all_parents_must_converge: false
         unified_job_template:
-          name: "{{ uninstall_log_analytics_agent_template.name }}"
+          name: "{{ job_templates.uninstall_log_analytics.name }}"
           type: job_template
           inventory: Azure
   when:
     - seed_lab_content
-    - install_arc_agent_template is defined
-    - replace_log_analytics_with_azure_monitor_template is defined
-    - uninstall_log_analytics_agent_template is defined
+    - job_templates.install_arc_agent.name is defined
+    - job_templates.replace_log_analytics_with_azure_monitor.name is defined
+    - job_templates.uninstall_log_analytics.name is defined
   tags:
     - workflows

--- a/roles/controller/tasks/workflows.yml
+++ b/roles/controller/tasks/workflows.yml
@@ -28,7 +28,7 @@
           name: "{{ delete_rhel_vm_template }}"
           type: job_template
   when:
-    - seed_content_lab
+    - seed_lab_content
     - create_rhel_vm_template is defined
     - rhel_vm_update_template is defined
     - delete_rhel_vm_template is defined
@@ -55,7 +55,7 @@
           type: job_template
           inventory: Azure
   when:
-    - seed_content_lab
+    - seed_lab_content
     - create_log_analytics_workspace_template is defined
     - install_log_analytics_agent_template is defined
   tags:
@@ -109,7 +109,7 @@
           type: job_template
           inventory: Azure
   when:
-    - seed_content_lab
+    - seed_lab_content
     - install_arc_agent_template is defined
     - replace_log_analytics_with_azure_monitor_template is defined
     - uninstall_log_analytics_agent_template is defined

--- a/roles/controller/tasks/workflows.yml
+++ b/roles/controller/tasks/workflows.yml
@@ -28,7 +28,7 @@
           name: "{{ job_templates.delete_rhel_vm.name }}"
           type: job_template
   when:
-    - seed_lab_content
+    - (seed_lab_content | bool)
     - workflows.ephemeral_workload.name is defined
     - job_templates.create_rhel_vm.name is defined
     - job_templates.dnf_update.name is defined
@@ -58,7 +58,7 @@
           type: job_template
           inventory: Azure
   when:
-    - seed_lab_content
+    - (seed_lab_content | bool)
     - workflows.install_log_analytics.name is defined
     - job_templates.create_log_analytics_ws.name is defined
     - job_templates.install_log_analytics.name is defined
@@ -115,7 +115,7 @@
           type: job_template
           inventory: Azure
   when:
-    - seed_lab_content
+    - (seed_lab_content | bool)
     - workflows.arc_log_migration.name is defined
     - job_templates.install_arc_agent.name is defined
     - job_templates.replace_log_analytics_with_azure_monitor.name is defined

--- a/roles/controller/tasks/workflows.yml
+++ b/roles/controller/tasks/workflows.yml
@@ -1,7 +1,7 @@
 ---
 - name: Create a workflow to create a RHEL VM, run an automation against the VM, and then destroy the VM
   ansible.controller.workflow_job_template:
-    name: Content Lab - Linux - Ephemeral VM Workflow
+    name: "{{ workflows.ephemeral_workload.name }}"
     inventory: "{{ inventories.localhost.name }}"
     workflow_nodes:
       - identifier: Create VM
@@ -29,6 +29,7 @@
           type: job_template
   when:
     - seed_lab_content
+    - workflows.ephemeral_workload.name is defined
     - job_templates.create_rhel_vm.name is defined
     - job_templates.dnf_update.name is defined
     - job_templates.delete_rhel_vm.name is defined
@@ -39,7 +40,7 @@
 
 - name: Azure - Install log analytics
   ansible.controller.workflow_job_template:
-    name: Content Lab - Azure - Install Log Analytics Workflow
+    name: "{{ workflows.install_log_analytics.name }}"
     description: Create a lot analytics workspace and install the log analytics agent on attached VMs.
     workflow_nodes:
       - identifier: Create Log Analytics Workspace
@@ -58,6 +59,7 @@
           inventory: Azure
   when:
     - seed_lab_content
+    - workflows.install_log_analytics.name is defined
     - job_templates.create_log_analytics_ws.name is defined
     - job_templates.install_log_analytics.name is defined
     - localhost_inventory is defined
@@ -67,7 +69,7 @@
 
 - name: Azure Arc - Replace Log Analytics with Azure Monitor
   ansible.controller.workflow_job_template:
-    name: Content Lab - Azure - Arc Log Migration
+    name: "{{ workflows.arc_log_migration.name }}"
     description: Migrate hosts from Azure Log Analytics Agent to Azure Monitor Agent with Azure Arc
     survey_enabled: true
     survey_spec:
@@ -114,6 +116,7 @@
           inventory: Azure
   when:
     - seed_lab_content
+    - workflows.arc_log_migration.name is defined
     - job_templates.install_arc_agent.name is defined
     - job_templates.replace_log_analytics_with_azure_monitor.name is defined
     - job_templates.uninstall_log_analytics.name is defined


### PR DESCRIPTION
release_summary: Refactored the collection with the intent of having a general use as a PoC for seeding content into automation controller.

breaking_changes:
  - All variable names have been edited and refactored. See `roles/controller/defaults/main.yml` for new variables and structure.

major_changes:
  - Separated the ability to deploy validated content and content lab content.
  - Flags to deploy validated content, content lab content, or both.

minor_changes:
  - Introduced change log.